### PR TITLE
Enforce Job Processor settings validation

### DIFF
--- a/LICENSE-3rdParty
+++ b/LICENSE-3rdParty
@@ -1,4 +1,4 @@
-Ardalis.GuardClauses 1.5.0
+Ardalis.GuardClauses 3.0.1
 fo-dicom 4.0.6
 KubernetesClient 2.0.27
 Microsoft .NET Core 3.1.6

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.0
+* :warning: All derived classes of `JobProcessorBase` must be decorated with a `ProcessorValidationAttribute` attribute so its settings can be validated
+when the Create Clara AE Title is called (POST /api/config/ClaraAeTitle)
+
 ## 0.7.0
 * :new: new: DICOM Adapter now accepts concurrent associations per AE Title and has a new Job Processor extension, designed
 to allow developers to extend and customize how received DICOM instances can be associated with a pipeline job.

--- a/src/API/IJobProcessorValidator.cs
+++ b/src/API/IJobProcessorValidator.cs
@@ -1,0 +1,34 @@
+/*
+ * Apache License, Version 2.0
+ * Copyright 2019-2020 NVIDIA Corporation
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+
+namespace Nvidia.Clara.DicomAdapter.API
+{
+    /// <summary>
+    /// Interface for providing a validator for JobProcessor.  See <see cref="ProcessorValidationAttribute"/>.
+    /// </summary>
+    public interface IJobProcessorValidator
+    {
+        /// <summary>
+        /// Validates process settings and throws if any invalid entires or ignored entries are found.
+        /// </summary>
+        /// <param name="aeTitle">AE Title of the associated settings.</param>
+        /// <param name="processorSettings">Settings of a job processor.</param>
+        void Validate(string aeTitle, Dictionary<string, string> processorSettings);
+    }
+}

--- a/src/API/Nvidia.Clara.Dicom.API.csproj
+++ b/src/API/Nvidia.Clara.Dicom.API.csproj
@@ -39,7 +39,7 @@ limitations under the License.
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ardalis.GuardClauses" Version="2.0.0" />
+    <PackageReference Include="Ardalis.GuardClauses" Version="3.0.1" />
     <PackageReference Include="fo-dicom.NetCore" Version="4.0.6" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.6" />    
     <PackageReference Include="Nvidia.Clara.Platform.Client" Version="0.7.2" />

--- a/src/API/ProcessorValidationAttribute.cs
+++ b/src/API/ProcessorValidationAttribute.cs
@@ -1,0 +1,35 @@
+/*
+ * Apache License, Version 2.0
+ * Copyright 2019-2020 NVIDIA Corporation
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq;
+using Dicom;
+
+namespace Nvidia.Clara.DicomAdapter.API
+{
+    /// <summary>
+    /// An attribute that is attached to a derived class of <see cref="JobProcessorBase"/>.
+    /// This attribute is used when the Create Clara AE Title (RESTful) API is called.
+    /// The API looks up the passed in value of Job Processor and reads the associated attribute 
+    /// to determine and instantiate <see cref="IJobProcessValidator"/> for validating process settings.
+    /// </summary>
+    [System.AttributeUsage(System.AttributeTargets.Class)]
+    public class ProcessorValidationAttribute : System.Attribute
+    {
+        public Type ValidatorType { get; set; }
+    }
+}

--- a/src/Common/Nvidia.Clara.Dicom.Common.csproj
+++ b/src/Common/Nvidia.Clara.Dicom.Common.csproj
@@ -39,7 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ardalis.GuardClauses" Version="2.0.0" />
+    <PackageReference Include="Ardalis.GuardClauses" Version="3.0.1" />
     <PackageReference Include="fo-dicom.NetCore" Version="4.0.6" />
     <PackageReference Include="System.IO.Abstractions" Version="12.1.1" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="12.1.1" />

--- a/src/Common/Test/ExtensionMethodsTest.cs
+++ b/src/Common/Test/ExtensionMethodsTest.cs
@@ -24,6 +24,20 @@ namespace Nvidia.Clara.DicomAdapter.Common.Test
 {
     public class ExtensionMethodsTest
     {
+        [RetryFact(DisplayName = "IsNull shall return false for empty input")]
+        public void IsNull_WithEmptyInput()
+        {
+            List<string> list = new List<string>();
+            Assert.False(list.IsNull());
+        }
+
+        [RetryFact(DisplayName = "IsNull shall return true for null input")]
+        public void IsNull_WithNullInput()
+        {
+            List<string> list = null;
+            Assert.True(list.IsNull());
+        }
+
         [RetryFact(DisplayName = "IsNullOrEmpty shall return true for null input")]
         public void IsNullOrEmpty_WithNullInput()
         {

--- a/src/Configuration/ConfigurationValidator.cs
+++ b/src/Configuration/ConfigurationValidator.cs
@@ -108,7 +108,8 @@ namespace Nvidia.Clara.DicomAdapter.Configuration
 
             Uri uri;
             if (string.IsNullOrWhiteSpace(services.ResultsServiceEndpoint) ||
-                !Uri.TryCreate(services.ResultsServiceEndpoint, UriKind.Absolute, out uri))
+                !Uri.TryCreate(services.ResultsServiceEndpoint, UriKind.Absolute, out uri) ||
+                !uri.IsWellFormedOriginalString())
             {
                 _logger.Log(LogLevel.Error, "Results Service API endpoint is not configured or invalid: DicomAdapter>services>results-service-endpoint.");
                 valid = false;

--- a/src/Configuration/Nvidia.Clara.Dicom.Configuration.csproj
+++ b/src/Configuration/Nvidia.Clara.Dicom.Configuration.csproj
@@ -39,7 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ardalis.GuardClauses" Version="2.0.0" />
+    <PackageReference Include="Ardalis.GuardClauses" Version="3.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.6" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.6" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/src/Configuration/Test/ConfigurationValidatorTest.cs
+++ b/src/Configuration/Test/ConfigurationValidatorTest.cs
@@ -227,7 +227,7 @@ namespace Nvidia.Clara.DicomAdapter.Configuration.Test
         public void ServicesWithMalformedResultServiceEndpoint()
         {
             var config = MockValidConfiguration();
-            config.Services.ResultsServiceEndpoint = "htp://zzz.com:";
+            config.Services.ResultsServiceEndpoint = "http://www.contoso.com/path???/file name";
 
             var valid = new ConfigurationValidator(logger.Object).Validate("", config);
 

--- a/src/Configuration/Test/ConfigurationValidatorTest.cs
+++ b/src/Configuration/Test/ConfigurationValidatorTest.cs
@@ -42,6 +42,22 @@ namespace Nvidia.Clara.DicomAdapter.Configuration.Test
             Assert.True(valid == ValidateOptionsResult.Success);
         }
 
+        [RetryFact(DisplayName = "ConfigurationValidator test with duplicate Clara AE titles")]
+        public void DuplicateClaraAeTitles()
+        {
+            var config = MockValidConfiguration();
+            config.Dicom.Scp.AeTitles.Add(new ClaraApplicationEntity
+            {
+                AeTitle = "AET",
+                Name = "AET",
+                ProcessorSettings = new System.Collections.Generic.Dictionary<string, string>() { { "key1", "value1" } }
+            });
+
+            var valid = new ConfigurationValidator(logger.Object).Validate("", config);
+            Assert.False(valid == ValidateOptionsResult.Success);
+            logger.VerifyLogging($"DicomAdapter>dicom>scp>ae-titles>AET already exists.", LogLevel.Error, Times.Once());
+        }
+
         [RetryFact(DisplayName = "ConfigurationValidator test with invalid SCP port number")]
         public void InvalidScpPort()
         {
@@ -143,6 +159,19 @@ namespace Nvidia.Clara.DicomAdapter.Configuration.Test
             logger.VerifyLogging($"No DICOM SCP source configured: DicomAdapter>dicom>scp>sources. All associations will be accepted.", LogLevel.Warning, Times.Once());
         }
 
+        [RetryFact(DisplayName = "ConfigurationValidator test when reading sources from CRD which is OK")]
+        public void ReadSourcesFromCrd_IsStillValid()
+        {
+            var config = MockValidConfiguration();
+            config.ReadAeTitlesFromCrd = true;
+            config.Dicom.Scp.Sources.Clear();
+
+            var valid = new ConfigurationValidator(logger.Object).Validate("", config);
+
+            Assert.True(valid == ValidateOptionsResult.Success);
+            logger.VerifyLogging($"DICOM Source AE Titles will be read from Kubernetes Custom Resource.", LogLevel.Information, Times.Once());
+        }
+
         [RetryFact(DisplayName = "ConfigurationValidator test with invalid source settings")]
         public void ScpSourceWithInvalidValues()
         {
@@ -158,6 +187,18 @@ namespace Nvidia.Clara.DicomAdapter.Configuration.Test
             logger.VerifyLogging($"Invalid host name/IP address '{config.Dicom.Scp.Sources[0].HostIp}' specified in DicomAdapter>dicom>scp>sources>{config.Dicom.Scp.Sources[0].AeTitle}.", LogLevel.Error, Times.Once());
         }
 
+        [RetryFact(DisplayName = "ConfigurationValidator test with reading destinations from CRDwhich is still OK.")]
+        public void ReadDestinationsFromCrd_IsStillValid()
+        {
+            var config = MockValidConfiguration();
+            config.ReadAeTitlesFromCrd = true;
+
+            var valid = new ConfigurationValidator(logger.Object).Validate("", config);
+
+            Assert.True(valid == ValidateOptionsResult.Success);
+            logger.VerifyLogging($"Destination AE Titles will be read from Kubernetes Custom Resource.", LogLevel.Information, Times.Once());
+        }
+
         [RetryFact(DisplayName = "ConfigurationValidator test with no destinations defined which is still OK.")]
         public void NoDestinations_IsStillValid()
         {
@@ -168,6 +209,30 @@ namespace Nvidia.Clara.DicomAdapter.Configuration.Test
 
             Assert.True(valid == ValidateOptionsResult.Success);
             logger.VerifyLogging($"No DICOM SCU destination configured: DicomAdapter>dicom>scu>destinations.", LogLevel.Warning, Times.Once());
+        }
+
+        [RetryFact(DisplayName = "ConfigurationValidator test with missing results service endpoint")]
+        public void ServicesWithNullResultServiceEndpoint()
+        {
+            var config = MockValidConfiguration();
+            config.Services.ResultsServiceEndpoint = " ";
+
+            var valid = new ConfigurationValidator(logger.Object).Validate("", config);
+
+            Assert.Equal("See console output for details.", valid.FailureMessage);
+            logger.VerifyLogging($"Results Service API endpoint is not configured or invalid: DicomAdapter>services>results-service-endpoint.", LogLevel.Error, Times.Once());
+        }
+
+        [RetryFact(DisplayName = "ConfigurationValidator test with malformed results service endpoint")]
+        public void ServicesWithMalformedResultServiceEndpoint()
+        {
+            var config = MockValidConfiguration();
+            config.Services.ResultsServiceEndpoint = "htp://zzz.com:";
+
+            var valid = new ConfigurationValidator(logger.Object).Validate("", config);
+
+            Assert.Equal("See console output for details.", valid.FailureMessage);
+            logger.VerifyLogging($"Results Service API endpoint is not configured or invalid: DicomAdapter>services>results-service-endpoint.", LogLevel.Error, Times.Once());
         }
 
         [RetryFact(DisplayName = "ConfigurationValidator test with missing platform endpoint")]
@@ -212,7 +277,7 @@ namespace Nvidia.Clara.DicomAdapter.Configuration.Test
             config.Dicom.Scp.AeTitles.Add(new ClaraApplicationEntity { });
 
             config.Services.PlatformEndpoint = "host:port";
-            config.Services.ResultsServiceEndpoint = "http://uri-to-some-api/bla-bla";
+            config.Services.ResultsServiceEndpoint = "http://1.2.3.4:8080/bla-bla";
             return config;
         }
     }

--- a/src/Nvidia.Clara.Dicom.sln
+++ b/src/Nvidia.Clara.Dicom.sln
@@ -33,6 +33,19 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nvidia.Clara.Dicom.DicomWeb
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nvidia.Clara.Dicom.DicomWeb.Client.CLI", "DicomWebClient\CLI\Nvidia.Clara.Dicom.DicomWeb.Client.CLI.csproj", "{5E255EB0-FBA1-4A54-BC47-E143B304E85D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution", "Solution", "{47427A06-F48C-4884-B2A4-218D369BBB76}"
+	ProjectSection(SolutionItems) = preProject
+		..\.gitignore = ..\.gitignore
+		..\build.sh = ..\build.sh
+		..\codecov.yml = ..\codecov.yml
+		..\CONTRIBUTING.md = ..\CONTRIBUTING.md
+		..\Dockerfile = ..\Dockerfile
+		..\LICENSE = ..\LICENSE
+		..\LICENSE-3rdParty = ..\LICENSE-3rdParty
+		..\README.md = ..\README.md
+		..\VERSION = ..\VERSION
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Server/Nvidia.Clara.DicomAdapter.csproj
+++ b/src/Server/Nvidia.Clara.DicomAdapter.csproj
@@ -54,7 +54,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ardalis.GuardClauses" Version="2.0.0" />
+    <PackageReference Include="Ardalis.GuardClauses" Version="3.0.1" />
     <PackageReference Include="fo-dicom.NetCore" Version="4.0.6" />
     <PackageReference Include="fo-dicom.Serilog" Version="4.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.6" />

--- a/src/Server/Processors/AeTitleJobProcessor.cs
+++ b/src/Server/Processors/AeTitleJobProcessor.cs
@@ -33,6 +33,7 @@ using Nvidia.Clara.Platform;
 
 namespace Nvidia.Clara.DicomAdapter.Server.Processors
 {
+    [ProcessorValidation(ValidatorType = typeof(AeTitleJobProcessorValidator))]
     public class AeTitleJobProcessor : JobProcessorBase
     {
         private class InstanceCollection : List<InstanceStorageInfo>, IDisposable

--- a/src/Server/Processors/AeTitleJobProcessorValidator.cs
+++ b/src/Server/Processors/AeTitleJobProcessorValidator.cs
@@ -1,0 +1,147 @@
+/*
+ * Apache License, Version 2.0
+ * Copyright 2019-2020 NVIDIA Corporation
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Ardalis.GuardClauses;
+using Microsoft.Extensions.Logging;
+using Nvidia.Clara.DicomAdapter.API;
+using Nvidia.Clara.DicomAdapter.Common;
+using Nvidia.Clara.DicomAdapter.Configuration;
+using Nvidia.Clara.DicomAdapter.Server.Services.Disk;
+using Nvidia.Clara.DicomAdapter.Server.Services.Scp;
+using Nvidia.Clara.Platform;
+
+namespace Nvidia.Clara.DicomAdapter.Server.Processors
+{
+    public class AeTitleJobProcessorValidator : IJobProcessorValidator
+    {
+        private readonly ILogger<AeTitleJobProcessorValidator> _logger;
+
+        public AeTitleJobProcessorValidator(ILogger<AeTitleJobProcessorValidator> logger)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public void Validate(string aeTitle, Dictionary<string, string> processorSettings)
+        {
+            Guard.Against.NullOrWhiteSpace(aeTitle, nameof(aeTitle));
+            Guard.Against.Null(processorSettings, nameof(processorSettings));
+
+            var valid = true;
+            var settingKeys = processorSettings.Keys.ToList();
+            var errors = new StringBuilder();
+            _logger.Log(LogLevel.Information, "Validating AE Title '{0}' processor settings.", aeTitle);
+
+            string setting = string.Empty;
+            if (processorSettings.TryGetValue("timeout", out setting))
+            {
+                if (!int.TryParse(setting, out int timeout) || timeout < 0)
+                {
+                    valid = false;
+                    var errorMessage = $"Invalid processor setting 'timeout' specified for AE Title {aeTitle}.";
+                    errors.AppendLine($"[ERROR] {errorMessage}");
+                    _logger.Log(LogLevel.Error, errorMessage);
+                }
+                settingKeys.Remove("timeout");
+            }
+
+            if (processorSettings.TryGetValue("jobRetryDelay", out setting))
+            {
+                if (!int.TryParse(setting, out int delay))
+                {
+                    valid = false;
+                    var errorMessage = $"Invalid processor setting 'jobRetryDelay' specified for AE Title {aeTitle}.";
+                    errors.AppendLine($"[ERROR] {errorMessage}");
+                    _logger.Log(LogLevel.Error, errorMessage);
+                }
+                settingKeys.Remove("jobRetryDelay");
+            }
+
+            if (processorSettings.TryGetValue("priority", out setting))
+            {
+                if (!Enum.TryParse(setting, true, out JobPriority priority))
+                {
+                    valid = false;
+                    var errorMessage = $"Invalid processor setting 'priority' specified for AE Title {aeTitle}.";
+                    errors.AppendLine($"[ERROR] {errorMessage}");
+                    _logger.Log(LogLevel.Error, errorMessage);
+                }
+                settingKeys.Remove("priority");
+            }
+
+            if (processorSettings.TryGetValue("groupBy", out setting))
+            {
+                try
+                {
+                    Dicom.DicomTag.Parse(setting);
+                }
+                catch (System.Exception ex)
+                {
+                    valid = false;
+                    var errorMessage = $"Invalid processor setting 'groupBy' specified for AE Title {aeTitle}.";
+                    errors.AppendLine($"[ERROR] {errorMessage}");
+                    _logger.Log(LogLevel.Error, ex, errorMessage);
+                }
+                settingKeys.Remove("groupBy");
+            }
+
+
+            var pipelines = 0;
+            foreach (var key in processorSettings.Keys)
+            {
+                if (key.StartsWith("pipeline-", StringComparison.OrdinalIgnoreCase))
+                {
+                    var name = key.Substring(9);
+                    var value = processorSettings[key];
+                    settingKeys.Remove(key);
+                    pipelines++;
+                }
+            }
+
+            if (pipelines == 0)
+            {
+                valid = false;
+                var errorMessage = $"No pipeline defined for AE Title {aeTitle}.";
+                errors.AppendLine($"[ERROR] {errorMessage}");
+                _logger.Log(LogLevel.Error, errorMessage);
+            }
+
+            if (settingKeys.Count > 0)
+            {
+                valid = false; // treat any unprocessed settings as invalid
+                foreach (var key in settingKeys)
+                {
+                    var errorMessage = $"Processor setting ignored {key}={processorSettings[key]}.";
+                    errors.AppendLine($"[WARNING] {errorMessage}");
+                    _logger.Log(LogLevel.Warning, errorMessage);
+                }
+            }
+
+            if (!valid)
+            {
+                throw new ConfigurationException(errors.ToString());
+            }
+        }
+    }
+}

--- a/src/Server/Services/Http/CrdControllers.cs
+++ b/src/Server/Services/Http/CrdControllers.cs
@@ -1,20 +1,21 @@
 ﻿/*
- * Apache License, Version 2.0
- * Copyright 2019-2020 NVIDIA Corporation
- * 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * 
- *     http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* Apache License, Version 2.0
+* Copyright 2019-2020 NVIDIA Corporation
+* 
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* 
+*     http://www.apache.org/licenses/LICENSE-2.0
+* 
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
+using System;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -29,12 +30,13 @@ namespace Nvidia.Clara.DicomAdapter.Server.Services.Http
     public class ClaraAeTitleController : CrdCrudControllerBase<ClaraAeTitleController, ClaraApplicationEntity>
     {
         public ClaraAeTitleController(
+            IServiceProvider serviceProvider,
             IHttpContextAccessor httpContextAccessor,
             ILogger<ClaraAeTitleController> logger,
             IKubernetesWrapper kubernetesClient,
             ConfigurationValidator configurationValidator,
             IOptions<DicomAdapterConfiguration> dicomAdapterConfiguration)
-            : base(httpContextAccessor, logger, kubernetesClient, CustomResourceDefinition.ClaraAeTitleCrd, configurationValidator, dicomAdapterConfiguration)
+            : base(serviceProvider, httpContextAccessor, logger, kubernetesClient, CustomResourceDefinition.ClaraAeTitleCrd, configurationValidator, dicomAdapterConfiguration)
         {
         }
     }
@@ -44,12 +46,13 @@ namespace Nvidia.Clara.DicomAdapter.Server.Services.Http
     public class SourceAeTitleController : CrdCrudControllerBase<SourceAeTitleController, SourceApplicationEntity>
     {
         public SourceAeTitleController(
+            IServiceProvider serviceProvider,
             IHttpContextAccessor httpContextAccessor,
             ILogger<SourceAeTitleController> logger,
             IKubernetesWrapper kubernetesClient,
             ConfigurationValidator configurationValidator,
             IOptions<DicomAdapterConfiguration> dicomAdapterConfiguration)
-            : base(httpContextAccessor, logger, kubernetesClient, CustomResourceDefinition.SourceAeTitleCrd, configurationValidator, dicomAdapterConfiguration)
+            : base(serviceProvider, httpContextAccessor, logger, kubernetesClient, CustomResourceDefinition.SourceAeTitleCrd, configurationValidator, dicomAdapterConfiguration)
         {
         }
     }
@@ -59,12 +62,13 @@ namespace Nvidia.Clara.DicomAdapter.Server.Services.Http
     public class DestinationAeTitleController : CrdCrudControllerBase<DestinationAeTitleController, DestinationApplicationEntity>
     {
         public DestinationAeTitleController(
+            IServiceProvider serviceProvider,
             IHttpContextAccessor httpContextAccessor,
             ILogger<DestinationAeTitleController> logger,
             IKubernetesWrapper kubernetesClient,
             ConfigurationValidator configurationValidator,
             IOptions<DicomAdapterConfiguration> dicomAdapterConfiguration)
-            : base(httpContextAccessor, logger, kubernetesClient, CustomResourceDefinition.DestinationAeTitleCrd, configurationValidator, dicomAdapterConfiguration)
+            : base(serviceProvider, httpContextAccessor, logger, kubernetesClient, CustomResourceDefinition.DestinationAeTitleCrd, configurationValidator, dicomAdapterConfiguration)
         {
         }
     }

--- a/src/Server/Test/Unit/Processors/AeTitleJobProcessorValidatorTest.cs
+++ b/src/Server/Test/Unit/Processors/AeTitleJobProcessorValidatorTest.cs
@@ -1,0 +1,141 @@
+/*
+ * Apache License, Version 2.0
+ * Copyright 2019-2020 NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.Extensions.Logging;
+using Moq;
+using Nvidia.Clara.DicomAdapter.Configuration;
+using Nvidia.Clara.DicomAdapter.Server.Processors;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Nvidia.Clara.DicomAdapter.Test.Unit
+{
+    public class AeTitleJobProcessorValidatorTest
+    {
+        private Mock<ILogger<AeTitleJobProcessorValidator>> _logger;
+
+        public AeTitleJobProcessorValidatorTest()
+        {
+            _logger = new Mock<ILogger<AeTitleJobProcessorValidator>>();
+        }
+
+        [Fact(DisplayName = "Constructor - shall throw with no logger")]
+        public void Constructor_ThrowsIfNoLogger()
+        {
+            Assert.Throws<ArgumentNullException>(() => new AeTitleJobProcessorValidator(null));
+        }
+
+        [Fact(DisplayName = "Validate - shall throw with no AE title")]
+        public void Validate_ThrowsWithNullEmptyAeTitle()
+        {
+            var validator = new AeTitleJobProcessorValidator(_logger.Object);
+            Assert.Throws<ArgumentNullException>(() => validator.Validate(null, new Dictionary<string, string>()));
+            Assert.Throws<ArgumentException>(() => validator.Validate(" ", new Dictionary<string, string>()));
+        }
+
+        [Fact(DisplayName = "Validate - shall throw when processorSettings is null")]
+        public void Validate_ShallThrowWithNullProcessorSettings()
+        {
+            var validator = new AeTitleJobProcessorValidator(_logger.Object);
+            Assert.Throws<ArgumentNullException>(() => validator.Validate("aet", null));
+        }
+
+        [Fact(DisplayName = "Validate - shall throw with bad timeout value")]
+        public void Validate_ShallThrowWithBadTimeoutValue()
+        {
+            var validator = new AeTitleJobProcessorValidator(_logger.Object);
+            var settings = new Dictionary<string, string>();
+            settings.Add("timeout", "a");
+            Assert.Throws<ConfigurationException>(() => validator.Validate("aet", settings));
+
+            settings["timeout"] = "-1";
+            Assert.Throws<ConfigurationException>(() => validator.Validate("aet", settings));
+        }
+
+        [Fact(DisplayName = "Validate - shall throw with bad jobRetryDelay value")]
+        public void Validate_ShallThrowWithBadJobRetryDelayValue()
+        {
+            var validator = new AeTitleJobProcessorValidator(_logger.Object);
+            var settings = new Dictionary<string, string>();
+            settings.Add("jobRetryDelay", "a");
+            Assert.Throws<ConfigurationException>(() => validator.Validate("aet", settings));
+
+            settings["jobRetryDelay"] = "-1";
+            Assert.Throws<ConfigurationException>(() => validator.Validate("aet", settings));
+        }
+
+        [Fact(DisplayName = "Validate - shall throw with bad priority value")]
+        public void Validate_ShallThrowWithBadJoPriorityValue()
+        {
+            var validator = new AeTitleJobProcessorValidator(_logger.Object);
+            var settings = new Dictionary<string, string>();
+            settings.Add("priority", "SonicSpeed");
+            Assert.Throws<ConfigurationException>(() => validator.Validate("aet", settings));
+
+            settings["priority"] = "-1";
+            Assert.Throws<ConfigurationException>(() => validator.Validate("aet", settings));
+        }
+
+        [Fact(DisplayName = "Validate - shall throw with bad groupBy value")]
+        public void Validate_ShallThrowWithBadGroupByyValue()
+        {
+            var validator = new AeTitleJobProcessorValidator(_logger.Object);
+            var settings = new Dictionary<string, string>();
+            settings.Add("groupBy", "0000000");
+            Assert.Throws<ConfigurationException>(() => validator.Validate("aet", settings));
+
+            settings["groupBy"] = "-1";
+            Assert.Throws<ConfigurationException>(() => validator.Validate("aet", settings));
+        }
+
+        [Fact(DisplayName = "Validate - shall throw with no pipelines defined")]
+        public void Validate_ShallThrowWithNoPipelinesDefined()
+        {
+            var validator = new AeTitleJobProcessorValidator(_logger.Object);
+            var settings = new Dictionary<string, string>();
+            Assert.Throws<ConfigurationException>(() => validator.Validate("aet", settings));
+        }
+
+        [Fact(DisplayName = "Validate - throw if settings are not recognized")]
+        public void Validate_ShallThrowIfSettingsAreNotRecognized()
+        {
+            var validator = new AeTitleJobProcessorValidator(_logger.Object);
+            var settings = new Dictionary<string, string>();
+            settings.Add("unknown", "abc");
+            settings.Add("time out", "typoe");
+            Assert.Throws<ConfigurationException>(() => validator.Validate("aet", settings));
+        }
+
+        [Fact(DisplayName = "Validate - passes validation")]
+        public void Validate_PassesValidation()
+        {
+            var validator = new AeTitleJobProcessorValidator(_logger.Object);
+            var settings = new Dictionary<string, string>();
+            settings.Add("timeout", "100");
+            settings.Add("jobRetryDelay", "100");
+            settings.Add("priority", "higher");
+            settings.Add("groupBy", "00100010");
+            settings.Add("pipeline-one", "ABCDEFGH");
+            validator.Validate("aet", settings);
+
+            settings["priority"] ="Higher";
+            settings["groupBy"] = "0010,0010";
+            validator.Validate("aet", settings);
+        }
+    }
+}


### PR DESCRIPTION
### Description
The Clara Creaet AE Title Web API does not validate processor settings until it is loaded by the CRD watcher.
PR introduces new `ProcessorValidationAttribute` attribute to decorate each derived `JobProcessorBase` class with a new `IJobProcessorValidator` interface to enforce validation when the API is called.

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [X] Breaking change (fix or new feature that would cause existing functionality to change).
- [X] New tests added to cover the changes.
- [X] All tests passed locally by running `./src/run-tests-in-docker.sh`.
- [X] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [X] User guide updated.
- [ ] NGC publishing metadata updated.
- [X] I have updated the changelog
