### PR TITLE
Fix unit test and pass exit code of docker run

### DIFF
--- a/src/API/Nvidia.Clara.Dicom.API.csproj
+++ b/src/API/Nvidia.Clara.Dicom.API.csproj
@@ -44,9 +44,9 @@ limitations under the License.
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.10" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.10" />    
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Nvidia.Clara.Platform.Client" Version="0.7.2" />
+    <PackageReference Include="Nvidia.Clara.Platform.Client" Version="0.7.3" />
     <PackageReference Include="Nvidia.Clara.ResultsService.Api" Version="0.7.2.13849" />
-    <PackageReference Include="System.IO.Abstractions" Version="12.1.1" />
+    <PackageReference Include="System.IO.Abstractions" Version="13.2.8" />
   </ItemGroup>
   
 </Project>

--- a/src/API/Test/Nvidia.Clara.Dicom.API.Test.csproj
+++ b/src/API/Test/Nvidia.Clara.Dicom.API.Test.csproj
@@ -31,14 +31,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xRetry" Version="1.1.0" />
+    <PackageReference Include="xRetry" Version="1.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="coverlet.collector" Version="1.3.0" />
-    <PackageReference Include="Moq" Version="4.14.5" />
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="12.1.1" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="12.1.1" />
+    <PackageReference Include="Moq" Version="4.15.2" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="13.2.8" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="13.2.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nvidia.Clara.Dicom.API.csproj" />

--- a/src/Common/Nvidia.Clara.Dicom.Common.csproj
+++ b/src/Common/Nvidia.Clara.Dicom.Common.csproj
@@ -41,8 +41,8 @@
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="3.0.1" />
     <PackageReference Include="fo-dicom.NetCore" Version="4.0.7" />
-    <PackageReference Include="System.IO.Abstractions" Version="12.1.1" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="12.1.1" />
+    <PackageReference Include="System.IO.Abstractions" Version="13.2.8" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="13.2.8" />
   </ItemGroup>
 
 </Project>

--- a/src/Common/Test/Nvidia.Clara.Dicom.Common.Test.csproj
+++ b/src/Common/Test/Nvidia.Clara.Dicom.Common.Test.csproj
@@ -31,9 +31,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="1.3.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-		<PackageReference Include="Moq" Version="4.14.5" />
-		<PackageReference Include="System.IO.Abstractions" Version="12.1.1" />
-		<PackageReference Include="xRetry" Version="1.1.0" />
+		<PackageReference Include="Moq" Version="4.15.2" />
+		<PackageReference Include="System.IO.Abstractions" Version="13.2.8" />
+		<PackageReference Include="xRetry" Version="1.2.0" />
 		<PackageReference Include="xunit" Version="2.4.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Configuration/Nvidia.Clara.Dicom.Configuration.csproj
+++ b/src/Configuration/Nvidia.Clara.Dicom.Configuration.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.10" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.10" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="System.IO.Abstractions" Version="12.1.1" />
+    <PackageReference Include="System.IO.Abstractions" Version="13.2.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Configuration/Test/Nvidia.Clara.Dicom.Configuration.Test.csproj
+++ b/src/Configuration/Test/Nvidia.Clara.Dicom.Configuration.Test.csproj
@@ -27,9 +27,9 @@ limitations under the License.
     <PackageReference Include="coverlet.collector" Version="1.3.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Moq" Version="4.14.5" />
+    <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="xRetry" Version="1.1.0" />
+    <PackageReference Include="xRetry" Version="1.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/DicomWebClient/Services/ServiceBase.cs
+++ b/src/DicomWebClient/Services/ServiceBase.cs
@@ -46,16 +46,22 @@ namespace Nvidia.Clara.Dicom.DicomWeb.Client
         {
             Guard.Against.NullOrWhiteSpace(uriPrefix, nameof(uriPrefix));
 
+            if (_httpClient.BaseAddress == null)
+            {
+                throw new InvalidOperationException("BaseAddress is not configured; call ConfigureServiceUris(...) first");
+            }
+
+            Uri newServiceUri = null;
             try
             {
-                var newServiceUri = new Uri(_httpClient.BaseAddress, uriPrefix);
+                newServiceUri = new Uri(_httpClient.BaseAddress, uriPrefix);
                 Guard.Against.MalformUri(newServiceUri, nameof(uriPrefix));
                 RequestServicePrefix = $"{uriPrefix.Trim('/')}/";
                 return true;
             }
             catch (Exception ex)
             {
-                _logger?.LogWarning($"Invalid urlPrefix provided: {uriPrefix}", ex);
+                _logger?.LogWarning($"Invalid urlPrefix provided: {uriPrefix} ({newServiceUri})", ex);
                 return false;
             }
         }

--- a/src/DicomWebClient/Test/DicomWebClientTest.cs
+++ b/src/DicomWebClient/Test/DicomWebClientTest.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using Nvidia.Clara.Dicom.DicomWeb.Client.API;
 using Xunit;
 using DicomWebClientClass = Nvidia.Clara.Dicom.DicomWeb.Client.DicomWebClient;
 
@@ -41,26 +42,48 @@ namespace Nvidia.Clara.Dicom.DicomWebClient.Test
             Assert.Throws<ArgumentNullException>(() => dicomWebClient.ConfigureServiceUris(null));
         }
 
-        [Fact(DisplayName = "ConfigureServiceUris - throws on malformed uri root")]
-        public void ConfigureServiceUris_ThrowsMalformedPrefixes()
-        {
-            var httpClient = new HttpClient();
-            var dicomWebClient = new DicomWebClientClass(httpClient, null);
-            var rootUri = new Uri(BaseUri);
-            Assert.Throws<ArgumentException>(() => dicomWebClient.ConfigureServiceUris(rootUri, "/bla\\?/"));
-            Assert.Throws<ArgumentException>(() => dicomWebClient.ConfigureServiceUris(rootUri, "/wado", "/bla\\?/"));
-            Assert.Throws<ArgumentException>(() => dicomWebClient.ConfigureServiceUris(rootUri, "/wado", "/qido", "/bla\\?/"));
-            Assert.Throws<ArgumentException>(() => dicomWebClient.ConfigureServiceUris(rootUri, "/wado", "/qido", "/stow", "/bla\\?/"));
-        }
-
-        [Fact(DisplayName = "ConfigureServiceUris - sets all URIs")]
+        [Fact(DisplayName = "ConfigureServiceUris - set rootUri")]
         public void ConfigureServiceUris_SetAllUris()
         {
             var httpClient = new HttpClient();
             var dicomWebClient = new DicomWebClientClass(httpClient, null);
             var rootUri = new Uri(BaseUri);
             dicomWebClient.ConfigureServiceUris(rootUri);
-            dicomWebClient.ConfigureServiceUris(rootUri, "/wado", "/qido", "/stow", "/delete");
+        }
+
+        [Theory(DisplayName = "ConfigureServiceUris - throws on malformed prefix")]
+        [InlineData(DicomWebServiceType.Qido, "/bla\\?/")]
+        [InlineData(DicomWebServiceType.Wado, "/bla\\?/")]
+        [InlineData(DicomWebServiceType.Stow, "/bla\\?/")]
+        public void ConfigureServicePrefix_ThrowsMalformedPrefixes(DicomWebServiceType serviceType, string prefix)
+        {
+            var httpClient = new HttpClient();
+            var dicomWebClient = new DicomWebClientClass(httpClient, null);
+            var rootUri = new Uri(BaseUri);
+            dicomWebClient.ConfigureServiceUris(rootUri);
+            Assert.Throws<ArgumentException>(() => dicomWebClient.ConfigureServicePrefix(serviceType, prefix));
+        }
+
+        [Fact(DisplayName = "ConfigureServicePrefix - throws if base address is not configured")]
+        public void ConfigureServicePrefix_ThrowsIfBaseAddressIsNotConfigured()
+        {
+            var httpClient = new HttpClient();
+            var dicomWebClient = new DicomWebClientClass(httpClient, null);
+            var rootUri = new Uri(BaseUri);
+            Assert.Throws<InvalidOperationException>(() => dicomWebClient.ConfigureServicePrefix(DicomWebServiceType.Qido, "/prefix"));
+        }
+
+        [Theory(DisplayName = "ConfigureServicePrefix - sets service prefix")]
+        [InlineData(DicomWebServiceType.Qido, "/qido/")]
+        [InlineData(DicomWebServiceType.Wado, "/wado")]
+        [InlineData(DicomWebServiceType.Stow, "/stow")]
+        public void ConfigureServicePrefix_SetsServicePrefix(DicomWebServiceType serviceType, string prefix)
+        {
+            var httpClient = new HttpClient();
+            var dicomWebClient = new DicomWebClientClass(httpClient, null);
+            var rootUri = new Uri(BaseUri);
+            dicomWebClient.ConfigureServiceUris(rootUri);
+            dicomWebClient.ConfigureServicePrefix(serviceType, prefix);
         }
 
         [Fact(DisplayName = "ConfigureAuthentication - throws if value is null")]

--- a/src/DicomWebClient/Test/Nvidia.Clara.Dicom.DicomWebClient.Test.csproj
+++ b/src/DicomWebClient/Test/Nvidia.Clara.Dicom.DicomWebClient.Test.csproj
@@ -26,11 +26,11 @@ limitations under the License. -->
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="3.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xRetry" Version="1.1.0" />
+    <PackageReference Include="xRetry" Version="1.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="coverlet.collector" Version="1.3.0" />
-    <PackageReference Include="Moq" Version="4.14.5" />
+    <PackageReference Include="Moq" Version="4.15.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Server/Nvidia.Clara.DicomAdapter.csproj
+++ b/src/Server/Nvidia.Clara.DicomAdapter.csproj
@@ -68,9 +68,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     <PackageReference Include="KubernetesClient" Version="3.0.7" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Nvidia.Clara.Platform.Client" Version="0.7.2" />
+    <PackageReference Include="Nvidia.Clara.Platform.Client" Version="0.7.3" />
     <PackageReference Include="Polly" Version="7.2.1" />
-    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
     <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
@@ -79,7 +79,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="serilogmetrics" Version="2.1.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="12.1.1" />
+    <PackageReference Include="System.IO.Abstractions" Version="13.2.8" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.11.1" />
   </ItemGroup>
 

--- a/src/Server/Test/Integration/Nvidia.Clara.DicomAdapter.Test.Integration.csproj
+++ b/src/Server/Test/Integration/Nvidia.Clara.DicomAdapter.Test.Integration.csproj
@@ -39,14 +39,14 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.10" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Moq" Version="4.14.5" />
+    <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="newtonsoft.json" Version="12.0.3" />
-    <PackageReference Include="Nvidia.Clara.Platform.Client" Version="0.7.2" />
+    <PackageReference Include="Nvidia.Clara.Platform.Client" Version="0.7.3" />
     <PackageReference Include="Nvidia.Clara.ResultsService.Api" Version="0.7.2.13849" />
     <PackageReference Include="Serilog.Sinks.TextWriter" Version="2.1.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="12.1.1" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="12.1.1" />
-    <PackageReference Include="xRetry" Version="1.1.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="13.2.8" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="13.2.8" />
+    <PackageReference Include="xRetry" Version="1.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Server/Test/IntegrationCrd/Nvidia.Clara.DicomAdapter.Test.IntegrationCrd.csproj
+++ b/src/Server/Test/IntegrationCrd/Nvidia.Clara.DicomAdapter.Test.IntegrationCrd.csproj
@@ -38,14 +38,14 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Moq" Version="4.14.5" />
+    <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="newtonsoft.json" Version="12.0.3" />
-    <PackageReference Include="Nvidia.Clara.Platform.Client" Version="0.7.2" />
+    <PackageReference Include="Nvidia.Clara.Platform.Client" Version="0.7.3" />
     <PackageReference Include="Nvidia.Clara.ResultsService.Api" Version="0.7.2.13849" />
     <PackageReference Include="Serilog.Sinks.TextWriter" Version="2.1.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="12.1.1" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="12.1.1" />
-    <PackageReference Include="xRetry" Version="1.1.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="13.2.8" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="13.2.8" />
+    <PackageReference Include="xRetry" Version="1.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Server/Test/Unit/Nvidia.Clara.DicomAdapter.Test.Unit.csproj
+++ b/src/Server/Test/Unit/Nvidia.Clara.DicomAdapter.Test.Unit.csproj
@@ -38,14 +38,14 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Moq" Version="4.14.5" />
+    <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="newtonsoft.json" Version="12.0.3" />
-    <PackageReference Include="Nvidia.Clara.Platform.Client" Version="0.7.2" />
+    <PackageReference Include="Nvidia.Clara.Platform.Client" Version="0.7.3" />
     <PackageReference Include="Nvidia.Clara.ResultsService.Api" Version="0.7.2.13849" />
     <PackageReference Include="Serilog.Sinks.TextWriter" Version="2.1.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="12.1.1" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="12.1.1" />
-    <PackageReference Include="xRetry" Version="1.1.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="13.2.8" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="13.2.8" />
+    <PackageReference Include="xRetry" Version="1.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/run-tests.sh
+++ b/src/run-tests.sh
@@ -47,6 +47,7 @@ if [ $# -eq 0 ]
   then
     echo "Executing all tests"
     dotnet test -v=$VERBOSITY --runtime linux-x64 --results-directory "$RESULTS_DIR" --collect:"XPlat Code Coverage" --settings "$SCRIPT_DIR/coverlet.runsettings" Nvidia.Clara.Dicom.sln
+    exit $?
 else
     while test $# -gt 0
     do


### PR DESCRIPTION
### Description
Fix unit test failures from #32 and the run-test-script not returning correct exit code of `docker run`.

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] All tests passed locally by running `./src/run-tests-in-docker.sh`.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] NGC publishing metadata updated.
- [ ] I have updated the changelog
