### PR TITLE
Use IHttpClientFactory instead of IDicomWebClient & User guide updates

### DIFF
--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -29,6 +29,8 @@ Request Content Type: JSON
 | priority       | number                                                                                             | Valid range 0-255. Please refer to [Nvidia.Clara.DicomAdapter.API.Rest.InferenceRequest.Priority](xref:Nvidia.Clara.DicomAdapter.API.Rest.InferenceRequest.Priority) for details. |
 | inputMetadata  | [inputMetadata](xref:Nvidia.Clara.DicomAdapter.API.Rest.InferenceRequestMetadata) object           | **Required**. Specifies the dataset associated with the inference request.                                                                                                        |
 | inputResources | array of [inputResource](xref:Nvidia.Clara.DicomAdapter.API.Rest.RequestInputDataResource) objects | **Required**. Data sources where the specified dataset to be retrieved. **Clara Only** Must include one `interface` that is type of `Algorithm`.                                  |
+| outputResources | array of [inputResource](xref:Nvidia.Clara.DicomAdapter.API.Rest.RequestOutputDataResource) objects | **Required**. Output destinations where results are exported to.
+
 
 ### Responses
 
@@ -114,12 +116,12 @@ Returns a created CRD formatted in JSON.
 | spec       | Clara AET | The Clara AE Title specs |
 
 
-| Code   | Description                                |
-| ------ | ------------------------------------------ |
-| 200    | CRD created successfully.                  |
-| 500    | Server error                               |
-| 503    | CRDs not enabled.                          |
-| others | Other errors received from Kubernetes API  |
+| Code   | Description                               |
+| ------ | ----------------------------------------- |
+| 200    | CRD created successfully.                 |
+| 500    | Server error                              |
+| 503    | CRDs not enabled.                         |
+| others | Other errors received from Kubernetes API |
 
 ### Example Request
 
@@ -167,19 +169,19 @@ Response Content Type: JSON
 
 Returns the created CRD formatted in JSON.
 
-| Name       | Type      | Description           |
-| ---------- | --------- | --------------------- |
-| apiVersion | string    | The CRD apiVersion    |
-| kind       | string    | Source                |
-| spec       | Clara AET | Clara AE Title specs  |
+| Name       | Type      | Description          |
+| ---------- | --------- | -------------------- |
+| apiVersion | string    | The CRD apiVersion   |
+| kind       | string    | Source               |
+| spec       | Clara AET | Clara AE Title specs |
 
 
-| Code   | Description                                |
-| ------ | ------------------------------------------ |
-| 200    | CRDs created successfully                  |
-| 500    | Server error                               |
-| 503    | CRDs not enabled                           |
-| others | Other errors received from Kubernetes API  |
+| Code   | Description                               |
+| ------ | ----------------------------------------- |
+| 200    | CRDs created successfully                 |
+| 500    | Server error                              |
+| 503    | CRDs not enabled                          |
+| others | Other errors received from Kubernetes API |
 
 ### Example Request
 
@@ -206,12 +208,12 @@ class definition for details.
 Required fields are listed below. Refer to the **Schema** section for a complete list.
 
 
-| Name    | Type   | Description                                                                   |
-| ------- | ------ | ----------------------------------------------------------------------------- |
-| name    | string | The name of the DICOM instance that can be referenced by the Results Service  |
-| hostIp  | string | The host name or IP address of the DICOM destination                          |
-| aeTitle | string | The AE Title of the DICOM destination                                         |
-| port    | int    | The Port of the DICOM destination                                             |
+| Name    | Type   | Description                                                                  |
+| ------- | ------ | ---------------------------------------------------------------------------- |
+| name    | string | The name of the DICOM instance that can be referenced by the Results Service |
+| hostIp  | string | The host name or IP address of the DICOM destination                         |
+| aeTitle | string | The AE Title of the DICOM destination                                        |
+| port    | int    | The Port of the DICOM destination                                            |
 
 
 
@@ -221,11 +223,11 @@ Response Content Type: JSON
 
 Returns the created CRD formatted in JSON.
 
-| Name       | Type      | Description           |
-| ---------- | --------- | --------------------- |
-| apiVersion | string    | CRD apiVersion        |
-| kind       | string    | Destination           |
-| spec       | Clara AET | Clara AE Title specs  |
+| Name       | Type      | Description          |
+| ---------- | --------- | -------------------- |
+| apiVersion | string    | CRD apiVersion       |
+| kind       | string    | Destination          |
+| spec       | Clara AET | Clara AE Title specs |
 
 
 | Code   | Description                                |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,39 +1,29 @@
 # Changelog
 
 ## 0.8.1
-* :new: new: DICOMweb client for WADO (Web Access to DICOM Objects) and a CLI is available in [DicomWebClient](https://github.com/NVIDIA/clara-dicom-adapter/tree/main/src/DicomWebClient).
-* :new: new: New REST API to trigger a new inference request is now avilable based on the specs defined by the American College of Radiology (ACR).  Please refer    to the API Documentation for more information.
-* :warning: All derived classes of [JobProcessorBase](xref:Nvidia.Clara.DicomAdapter.API.JobProcessorBase) must be decorated with a [ProcessorValidationAttribute]   (xref:Nvidia.Clara.DicomAdapter.API.ProcessorValidationAttribute) attribute so its settings can be validated
-  when the Create Clara AE Title is called (POST /api/config/ClaraAeTitle)
 
-## 0.8.0
-<<<<<<< HEAD
-* :new: new: DICOMweb client for WADO (Web Access to DICOM Objects) and a CLI is available in
-  [DicomWebClient](https://github.com/NVIDIA/clara-dicom-adapter/tree/main/src/DicomWebClient).
-* :new: new: New REST API to trigger a new inference request is now avilable based on the specs
-  defined by the American College of Radiology (ACR).  Please refer to the API Documentation for
-  more information.
-* :warning: All derived classes of [JobProcessorBase](xref:Nvidia.Clara.DicomAdapter.API.JobProcessorBase)
-  must be decorated with a [ProcessorValidationAttribute](xref:Nvidia.Clara.DicomAdapter.API.ProcessorValidationAttribute)
-  attribute so its settings can be validated when the Create Clara AE Title is called
-  (POST /api/config/ClaraAeTitle).
+- :new: new: DICOMweb client for WADO (Web Access to DICOM Objects)/QIDO (Query based on ID for DICOM Objects)/STOW 
+  (Store Over the Web) and a CLI is available in [DicomWebClient](https://github.com/NVIDIA/clara-dicom-adapter/tree/main/src/DicomWebClient).
+- :new: new: New REST API to trigger a new inference request is now avilable based on the specs defined by the 
+  American College of Radiology (ACR). Please refer to the API Documentation for more information.
+- :warning: All derived classes of [JobProcessorBase](xref:Nvidia.Clara.DicomAdapter.API.JobProcessorBase) must
+  be decorated with a [ProcessorValidationAttribute] (xref:Nvidia.Clara.DicomAdapter.API.ProcessorValidationAttribute) 
+  attribute so its settings can be validated when the Create Clara AE Title is called (POST /api/config/ClaraAeTitle)
 
 ## 0.7.0
-* :new: new: DICOM Adapter now accepts concurrent associations per AE Title and has a new Job
+
+- :new: new: DICOM Adapter now accepts concurrent associations per AE Title and has a new Job
   Processor extension that allows developers to extend and customize how to associate received DICOM
   instances with a pipeline job.
-* :warning: breaking: The YAML-formatted configuration file has been replaced and consolidated into
+- :warning: breaking: The YAML-formatted configuration file has been replaced and consolidated into
   a single `appsettings.json` file.
-
-
 
 ## 0.6.0
 
-* :new: new: The ability to configure *Clara AE-Title*s, *Sources*, and *Destinations* via
-  Kubernetes CRD has been added. This allows a user to add a new Clara AE-Title and 
+- :new: new: The ability to configure *Clara AE-Title*s, _Sources_, and _Destinations_ via
+  Kubernetes CRD has been added. This allows a user to add a new Clara AE-Title and
   associate it with a Clara Pipeline without restarting DICOM Adapter. DICOM sources and
   destinations can also be added via CRD.
-* :no_entry: removed: `timeout-group` is no longer supported. This can be replaced with a custom
+- :no_entry: removed: `timeout-group` is no longer supported. This can be replaced with a custom
   plug-in if required. `timeout` can still accept multiple associations and associate all
   received DICOM instances with a Clara job.
-

--- a/docs/setup/schema.md
+++ b/docs/setup/schema.md
@@ -35,6 +35,11 @@
         "sources": [] // a list know know DICOM sources
       },
       "scu": {
+        "export": {
+          "maximumRetries": 3, // number of retries the exporter shall perform before reporting failure to Results Service.
+          "failureThreshold" 0.5, // failure threshold for a task to be marked as failure.
+          "pollFrequencyMs": 500 // number of milliseconds each exporter shall poll tasks from Results Service,
+        }
         "aeTitle": "ClaraSCU", // AE Title of the SCU service
         "logDimseDatasets": false,  // whether or not to write command and data datasets to the log.
         "logDataPDUs": false, // whether or not to write message to log for each P-Data-TF PDU sent or received

--- a/src/Server/Program.cs
+++ b/src/Server/Program.cs
@@ -96,7 +96,7 @@ namespace Nvidia.Clara.DicomAdapter
                     services.AddSingleton<IJobStore, JobStore>();
                     services.AddSingleton<IInferenceRequestStore, InferenceRequestStore>();
 
-                    services.AddHttpClient<IDicomWebClient, DicomWebClient>(configure => configure.Timeout = TimeSpan.FromMinutes(60))
+                    services.AddHttpClient("dicomweb", configure => configure.Timeout = TimeSpan.FromMinutes(60))
                         .SetHandlerLifetime(TimeSpan.FromMinutes(60));
 
                     services.AddHostedService<K8sCrdMonitorService>();

--- a/src/Server/Services/Export/ExportServiceBase.cs
+++ b/src/Server/Services/Export/ExportServiceBase.cs
@@ -136,7 +136,7 @@ namespace Nvidia.Clara.DicomAdapter.Server.Services.Export
                 downloadActionBlock.Post(Agent);
                 downloadActionBlock.Complete();
                 reportingActionBlock.Completion.Wait();
-                _logger.Log(LogLevel.Information, "Export Service completed timer routine.");
+                _logger.Log(LogLevel.Debug, "Export Service completed timer routine.");
             }
             catch (AggregateException ex)
             {

--- a/src/Server/Test/Unit/Services/Export/ExportServiceBaseTest.cs
+++ b/src/Server/Test/Unit/Services/Export/ExportServiceBaseTest.cs
@@ -140,7 +140,7 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
 
             _resultsService.Verify(p => p.GetPendingJobs(TestExportService.AgentName, It.IsAny<CancellationToken>(), 10), Times.AtLeastOnce());
             await StopAndVerify(service);
-            _logger.VerifyLogging($"Export Service completed timer routine.", LogLevel.Information, Times.AtLeastOnce());
+            _logger.VerifyLogging($"Export Service completed timer routine.", LogLevel.Debug, Times.AtLeastOnce());
         }
 
 
@@ -172,7 +172,7 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
             Assert.False(exportCountdown.Wait(3000));
             _resultsService.Verify(p => p.GetPendingJobs(TestExportService.AgentName, It.IsAny<CancellationToken>(), 10), Times.AtLeastOnce());
             await StopAndVerify(service);
-            _logger.VerifyLogging($"Export Service completed timer routine.", LogLevel.Information, Times.AtLeastOnce());
+            _logger.VerifyLogging($"Export Service completed timer routine.", LogLevel.Debug, Times.AtLeastOnce());
         }
 
         [RetryFact(DisplayName = "Data flow test - payload download failure")]
@@ -249,7 +249,7 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
 
             await service.StartAsync(_cancellationTokenSource.Token);
             Assert.True(convertCountdown.Wait(3000));
-            Assert.True(exportCountdown.Wait(000));
+            Assert.True(exportCountdown.Wait(3000));
 
             _resultsService.Verify(p => p.GetPendingJobs(TestExportService.AgentName, It.IsAny<CancellationToken>(), 10), Times.AtLeastOnce());
             _payloadsApi.Verify(p => p.Download(tasks.First().PayloadId, tasks.First().Uris.First()), Times.Once());
@@ -303,7 +303,7 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
             _logger.VerifyLogging($"Task marked as successful.", LogLevel.Error, Times.Never());
 
             await StopAndVerify(service);
-            _logger.VerifyLogging($"Export Service completed timer routine.", LogLevel.Information, Times.AtLeastOnce());
+            _logger.VerifyLogging($"Export Service completed timer routine.", LogLevel.Debug, Times.AtLeastOnce());
         }
 
 

--- a/test/dicom-test-pipeline/dicom-test.yaml
+++ b/test/dicom-test-pipeline/dicom-test.yaml
@@ -35,6 +35,7 @@ operators:
       image: nvcr.io/nvidia/clara/register-results
       tag: 0.7.2-2010.1
       command: ["python", "register.py", "--agent", "ClaraSCU", "--data", "[\"MYPACS\"]"]
+      # command: ["python", "register.py", "--agent", "DICOMweb"]
   input:
   - from: dicom-test
     name: dcmout


### PR DESCRIPTION
### Description
* Use `IHttpClientFactory `instead of `IDicomWebClient `since `BaseAddress ` cannot be modified afterward, must initialize a new instance of DicomWebClient for every request.
* Update user guide for release

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] All tests passed locally by running `./src/run-tests-in-docker.sh`.
- [x] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [x] User guide updated.
- [ ] NGC publishing metadata updated.
- [x] I have updated the changelog
