### PR TITLE
Add branch version to helm chart

### DIFF
--- a/helm-chart/dicom-adapter/Chart.yaml
+++ b/helm-chart/dicom-adapter/Chart.yaml
@@ -17,7 +17,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for the DICOM Adapter
 name: dicom-adapter
-version: 0.0.0.0
+version: 0.8.1
 keywords:
   - nvidia
   - clara


### PR DESCRIPTION
### Description
When building this chart, it will default to using the version specified on line 20.
If using `helm package`, even with the version specified using the `--app-version` flag, the chart will still be recognized by the default Version value eg. when going to use `helm push`.
If taring the directory and naming the version with the tar command, again `helm push` only notices the metadata from this file. This results in errors when pushing to NGC.

Error message:
```
helm push dicom-adapter-0.8.1-rc1.tgz ngc
Pushing dicom-adapter-0.0.0.0.tgz to ngc...
Error: 409: nvidia/clara/dicom-adapter-0.0.0.0.tgz already exists
```
This value needs to be incremented in tandem with the Version file in the root directory (and for release branches).

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] All tests passed locally by running `./src/run-tests-in-docker.sh`.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] NGC publishing metadata updated.
- [ ] I have updated the changelog
