### PR TITLE
Update default number of concurrent associations

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,7 @@
   - `GET /health/live`
   - `GET /health/status`
 - :new: new: DICOM Adapter helm chart now supports helm v3.4.x.
+- :warning: Default number of concurrent associations have been changed to 25 for SCP and 8 for SCU. Please adjust accordingly.
 - :no_entry: removed: Clara AE Titles, source AE Titles and destination AE Titles can no longer be configured in the config file. Please use the Clara CLI to configure them.
 
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,7 @@
   - `GET /health/ready`
   - `GET /health/live`
   - `GET /health/status`
+- :new: new: DICOM Adapter helm chart now supports helm v3.4.x.
 - :no_entry: removed: Clara AE Titles, source AE Titles and destination AE Titles can no longer be configured in the config file. Please use the Clara CLI to configure them.
 
 

--- a/docs/setup/schema.md
+++ b/docs/setup/schema.md
@@ -32,7 +32,7 @@ database:
     "dicom": {
       "scp": {
         "port": 104, // DICOM SCP listening port. (default 104)
-        "maximumNumberOfAssociations": 100, // maximum number of concurrent associations. (range: 1-1000, default: 1000)
+        "maximumNumberOfAssociations": 25, // maximum number of concurrent associations. (range: 1-1000, default: 25)
         "verification": {
           "enabled": true, // respond to c-ECHO commands (default: true)
           "transferSyntaxes": [
@@ -53,7 +53,7 @@ database:
         "aeTitle": "ClaraSCU", // AE Title of the SCU service
         "logDimseDatasets": false,  // whether or not to write command and data datasets to the log.
         "logDataPDUs": false, // whether or not to write message to log for each P-Data-TF PDU sent or received
-        "maximumNumberOfAssociations": 2, // maximum number of outbound DICOM associations (range: 1-1000, default: 2)
+        "maximumNumberOfAssociations": 8, // maximum number of outbound DICOM associations (range: 1-100, default: 8)
       }
     },
     "storage" : {

--- a/src/Configuration/ConfigurationValidator.cs
+++ b/src/Configuration/ConfigurationValidator.cs
@@ -107,7 +107,7 @@ namespace Nvidia.Clara.DicomAdapter.Configuration
                 valid = false;
             }
 
-            if (string.IsNullOrWhiteSpace(services.Platform.Endpoint))
+            if (string.IsNullOrWhiteSpace(services.PlatformEndpoint))
             {
                 _validationErrors.Add("Clara Service API endpoint is not configured: DicomAdapter>services>platform-endpoint.");
                 valid = false;

--- a/src/Configuration/ConfigurationValidator.cs
+++ b/src/Configuration/ConfigurationValidator.cs
@@ -62,7 +62,7 @@ namespace Nvidia.Clara.DicomAdapter.Configuration
         private bool IsDicomScpConfigValid(ScpConfiguration scpConfiguration)
         {
             var valid = ValidationExtensions.IsPortValid("DicomAdapter>dicom>scp>port", scpConfiguration.Port, _validationErrors);
-            valid &= IsValueInRange("DicomAdapter>dicom>scp>max-associations", 1, Int32.MaxValue, scpConfiguration.MaximumNumberOfAssociations);
+            valid &= IsValueInRange("DicomAdapter>dicom>scp>max-associations", 1, 1000, scpConfiguration.MaximumNumberOfAssociations);
             valid &= AreVerificationTransferSyntaxesValid(scpConfiguration.Verification.TransferSyntaxes);
             return valid;
         }
@@ -70,7 +70,7 @@ namespace Nvidia.Clara.DicomAdapter.Configuration
         private bool IsDicomScuConfigValid(ScuConfiguration scuConfiguration)
         {
             var valid = ValidationExtensions.IsAeTitleValid("DicomAdapter>dicom>scu>aeTitle", scuConfiguration.AeTitle, _validationErrors);
-            valid &= IsValueInRange("DicomAdapter>dicom>scu>max-associations", 1, Int32.MaxValue, scuConfiguration.MaximumNumberOfAssociations);
+            valid &= IsValueInRange("DicomAdapter>dicom>scu>max-associations", 1, 100, scuConfiguration.MaximumNumberOfAssociations);
             return valid;
         }
 
@@ -107,7 +107,7 @@ namespace Nvidia.Clara.DicomAdapter.Configuration
                 valid = false;
             }
 
-            if (string.IsNullOrWhiteSpace(services.PlatformEndpoint))
+            if (string.IsNullOrWhiteSpace(services.Platform.Endpoint))
             {
                 _validationErrors.Add("Clara Service API endpoint is not configured: DicomAdapter>services>platform-endpoint.");
                 valid = false;

--- a/src/Configuration/ScpConfiguration.cs
+++ b/src/Configuration/ScpConfiguration.cs
@@ -34,7 +34,7 @@ namespace Nvidia.Clara.DicomAdapter.Configuration
         /// Gets or sets maximum number of simultaneous DICOM associations for the SCP service.
         /// </summary>
         [JsonProperty(PropertyName = "maximumNumberOfAssociations")]
-        public int MaximumNumberOfAssociations { get; set; } = 100;
+        public int MaximumNumberOfAssociations { get; set; } = 25;
 
         /// <summary>
         /// Gets or sets Verification (C-ECHO) service configuration

--- a/src/Configuration/ScuConfiguration.cs
+++ b/src/Configuration/ScuConfiguration.cs
@@ -46,7 +46,7 @@ namespace Nvidia.Clara.DicomAdapter.Configuration
         /// Gets or sets the maximum number of simultaneous DICOM associations for the SCU service.
         /// </summary>
         [JsonProperty(PropertyName = "maximumNumberOfAssociations")]
-        public int MaximumNumberOfAssociations { get; set; } = 2;
+        public int MaximumNumberOfAssociations { get; set; } = 8;
 
         /// <summary>
         /// Represents the <c>dicom>scu>export</c> section of the configuration file.

--- a/src/Configuration/Test/ConfigurationValidatorTest.cs
+++ b/src/Configuration/Test/ConfigurationValidatorTest.cs
@@ -63,7 +63,7 @@ namespace Nvidia.Clara.DicomAdapter.Configuration.Test
 
             var valid = new ConfigurationValidator(logger.Object).Validate("", config);
 
-            var validationMessage = $"Value of DicomAdapter>dicom>scp>max-associations must be between {1} and {Int32.MaxValue}.";
+            var validationMessage = $"Value of DicomAdapter>dicom>scp>max-associations must be between {1} and {1000}.";
             Assert.Equal(validationMessage, valid.FailureMessage);
             logger.VerifyLogging(validationMessage, LogLevel.Error, Times.Once());
         }


### PR DESCRIPTION
### Description
SCP default to 25 with a max of 1000.
SCU default to 8 with a max of 100.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] All tests passed locally by running `./src/run-tests-in-docker.sh`.
- [x] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [x] User guide updated.
- [ ] NGC publishing metadata updated.
- [x] I have updated the changelog
