### PR TITLE
Remove empty directories in temp storage

### DIFF
--- a/src/Configuration/StorageConfiguration.cs
+++ b/src/Configuration/StorageConfiguration.cs
@@ -24,7 +24,7 @@ namespace Nvidia.Clara.DicomAdapter.Configuration
         /// This is used to store all instances received to a temporary folder.
         /// </summary>
         /// <value></value>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "resultsServiceEndpoint")]
+        [Newtonsoft.Json.JsonProperty(PropertyName = "temporary")]
         public string Temporary { get; set; } = "./payloads";
     }
 }

--- a/src/Server/Test/Unit/Services/Disk/SpaceReclaimerServiceTest.cs
+++ b/src/Server/Test/Unit/Services/Disk/SpaceReclaimerServiceTest.cs
@@ -16,13 +16,16 @@
  */
 
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using Nvidia.Clara.DicomAdapter.API;
+using Nvidia.Clara.DicomAdapter.Configuration;
 using Nvidia.Clara.DicomAdapter.Server.Services.Disk;
 using Nvidia.Clara.DicomAdapter.Test.Shared;
 using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using xRetry;
@@ -36,6 +39,7 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
         private Mock<IInstanceCleanupQueue> _queue;
         private CancellationTokenSource _cancellationTokenSource;
         private IFileSystem _fileSystem;
+        private IOptions<DicomAdapterConfiguration> _configuration;
         private SpaceReclaimerService _service;
 
         public SpaceReclaimerServiceTest()
@@ -44,7 +48,10 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
             _logger = new Mock<ILogger<SpaceReclaimerService>>();
             _queue = new Mock<IInstanceCleanupQueue>();
             _fileSystem = new MockFileSystem();
-            _service = new SpaceReclaimerService(_queue.Object, _logger.Object, _fileSystem);
+
+            _configuration = Options.Create(new DicomAdapterConfiguration());
+            _configuration.Value.Storage.Temporary = "/payloads";
+            _service = new SpaceReclaimerService(_queue.Object, _logger.Object, _configuration, _fileSystem);
         }
 
         [RetryFact(DisplayName = "Shall honor cancellation request")]
@@ -70,9 +77,9 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
         public async Task ShallDeleteFiles()
         {
             var files = new List<string>() {
-                "/dir1/file1",
-                "/dir1/file2",
-                "/dir2/file1.exe"
+                "/payloads/dir1/file1",
+                "/payloads/dir1/file2",
+                "/payloads/dir2/file1.exe"
             };
             foreach (var file in files)
             {
@@ -102,6 +109,64 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
             {
                 Assert.False(_fileSystem.File.Exists(file));
             }
+            Assert.True(_fileSystem.Directory.Exists("/payloads"));
+
+            _logger.VerifyLogging("Cancellation requested.", LogLevel.Information, Times.Once());
+        }
+
+
+        [RetryFact(DisplayName = "Shall delete directories if empty")]
+        public async Task ShallDeleteDirectoriesIfEmpty()
+        {
+            var files = new List<string>() {
+                "/payloads/dir1/dir1.1/file1",
+                "/payloads/dir1/dir1.2/file2",
+                "/payloads/dir1/dir1.2/dir1.2.1/file4",
+                "/payloads/dir1/dir1.2/dir1.2.1/file5",
+                "/payloads/dir1/dir1.2/dir1.2.2/file6",
+                "/payloads/dir1/dir1.2/file3",
+                "/payloads/dir1/dir1.3/file7",
+                "/payloads/dir2/dir2.1/dir2.1.1/file1.exe"
+            };
+            foreach (var file in files)
+            {
+                _fileSystem.Directory.CreateDirectory(_fileSystem.Path.GetDirectoryName(file));
+                _fileSystem.File.Create(file);
+            }
+
+            var cancellationTokenSource = new CancellationTokenSource();
+            var stack = new Stack<string>(files.Where(p => !p.EndsWith("file3")));
+            _queue.Setup(p => p.Dequeue(It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    if (stack.TryPop(out string result))
+                        return result;
+
+                    cancellationTokenSource.Cancel();
+                    return null;
+                });
+
+            await _service.StartAsync(cancellationTokenSource.Token);
+            while (!cancellationTokenSource.IsCancellationRequested)
+                Thread.Sleep(100);
+
+            _queue.Verify(p => p.Dequeue(It.IsAny<CancellationToken>()), Times.AtLeast(7));
+
+            Assert.False(_fileSystem.File.Exists("/payloads/dir1/dir1.1/file1"));
+            Assert.False(_fileSystem.File.Exists("/payloads/dir1/dir1.2/file2"));
+            Assert.False(_fileSystem.File.Exists("/payloads/dir1/dir1.2/dir1.2.1/file4"));
+            Assert.False(_fileSystem.File.Exists("/payloads/dir1/dir1.2/dir1.2.1/file5"));
+            Assert.False(_fileSystem.File.Exists("/payloads/dir1/dir1.2/dir1.2.2/file6"));
+            Assert.False(_fileSystem.File.Exists("/payloads/dir2/dir2.1/dir2.1.1/file1.exe"));
+            Assert.False(_fileSystem.File.Exists("/payloads/dir1/dir1.3/file7"));
+            Assert.False(_fileSystem.Directory.Exists("/payloads/dir1/dir1.3"));
+            Assert.False(_fileSystem.Directory.Exists("/payloads/dir2"));
+
+            Assert.True(_fileSystem.File.Exists("/payloads/dir1/dir1.2/file3"));
+            Assert.True(_fileSystem.Directory.Exists("/payloads/dir1/dir1.2"));
+            Assert.True(_fileSystem.Directory.Exists("/payloads/dir1"));
+            Assert.True(_fileSystem.Directory.Exists("/payloads"));
+
             _logger.VerifyLogging("Cancellation requested.", LogLevel.Information, Times.Once());
         }
     }

--- a/src/Server/appsettings.Development.json
+++ b/src/Server/appsettings.Development.json
@@ -16,7 +16,7 @@
       }
     },
     "services": {
-      "platformEndpoint": "10.104.93.112:50051",
+      "platformEndpoint": "192.168.20.209:7000",
       "resultsServiceEndpoint": "http://10.101.32.66:8088"
     },
     "storage": {


### PR DESCRIPTION
### Description
Update `SpaceReclaimerService` to also remove directories when removing files if the directory where the file resides is empty after deletion of the file itself.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] All tests passed locally by running `./src/run-tests-in-docker.sh`.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] NGC publishing metadata updated.
- [ ] I have updated the changelog
