### PR TITLE
Use "name" as the key for Clara AETs

### DIFF
--- a/src/Database/ClaraApplicationEntityConfiguration.cs
+++ b/src/Database/ClaraApplicationEntityConfiguration.cs
@@ -29,9 +29,9 @@ namespace Nvidia.Clara.DicomAdapter.Database
         {
             var jsonSeriealizerSettings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
             
-            builder.HasKey(j => j.AeTitle);
-
-            builder.Property(j => j.Name).IsRequired();
+            builder.HasKey(j => j.Name);
+            
+            builder.Property(j => j.AeTitle).IsRequired();
 
             builder.Property(j => j.OverwriteSameInstance).IsRequired().HasDefaultValue(false);
 

--- a/src/Server/Services/Export/ScuExportService.cs
+++ b/src/Server/Services/Export/ScuExportService.cs
@@ -75,8 +75,9 @@ namespace Nvidia.Clara.DicomAdapter.Server.Services.Scu
                 {
                     outputJob = CreateOutputJobFromTask(task);
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    _logger.Log(LogLevel.Error, ex, "Error converting task.");
                     ReportFailure(task, cancellationToken).Wait();
                     continue;
                 }


### PR DESCRIPTION
### Description
* Instead of using the AET as primary key, use the name as primary key to allow the same AET to be added.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] All tests passed locally by running `./src/run-tests-in-docker.sh`.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] NGC publishing metadata updated.
- [ ] I have updated the changelog
