### PR TITLE
Configurable retry delay in job submission service

### DIFF
--- a/docs/setup/schema.md
+++ b/docs/setup/schema.md
@@ -58,6 +58,8 @@ database:
     },
     "services": {
       "platform": {
+        "maxRetries": 3, // maximum number of retries to be performed when an execution attempt fails to connect to connect o Clara Platform.
+        "retryDelaySeconds": 180, // number of seconds to wait before attempting to retry.
         "uploadMetadata": false, // whether or not to upload metadata with the associated job defined in the `metadataDicomSource` property.
         "metadataDicomSource": [ // list of DICOM tags that are used when extracting metadata to be associated with an inference job.
           "0008,0020",

--- a/helm-chart/dicom-adapter/files/appsettings.json
+++ b/helm-chart/dicom-adapter/files/appsettings.json
@@ -22,6 +22,8 @@
     },
     "services": {
       "platform": {
+        "maxRetries": 3,
+        "retryDelaySeconds": 180, 
         "uploadMetadata": false,
         "metadataDicomSource": [
           "0008,0020",

--- a/src/API/IJobs.cs
+++ b/src/API/IJobs.cs
@@ -16,6 +16,7 @@
  */
 
 using Nvidia.Clara.Platform;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -25,6 +26,7 @@ namespace Nvidia.Clara.DicomAdapter.API
     {
         public string JobId { get; set; }
         public string PayloadId { get; set; }
+
     }
 
     /// <summary>

--- a/src/API/IJobsRepository.cs
+++ b/src/API/IJobsRepository.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using Nvidia.Clara.Platform;
 
 namespace Nvidia.Clara.DicomAdapter.API
 {
@@ -35,17 +36,8 @@ namespace Nvidia.Clara.DicomAdapter.API
         /// <c>New</c> makes a copy of the instances to a temporary location that is to be
         /// uploaded by the `Nvidia.Clara.DicomAdapter.Server.Services.Jobs.JobSubmissionService`.
         /// </summary>
-        /// <param name="job"><see cref="Nvidia.Clara.DicomAdapter.API.Job" /> includes the Job ID and Payload ID returned from the Clara Job.Create API call.</param>
-        /// <param name="jobName">Name of the job.</param>
-        /// <param name="instances">DICOM instances to be uploaded to the payload.</param>
-        Task Add(Job job, string jobName, IList<InstanceStorageInfo> instances);
-
-        /// <summary>
-        /// Updates job status.
-        /// </summary>
-        /// <param name="inferenceJob">Metadata of an inference request.</param>
-        /// <param name="status">Status of the request.</param>
-        Task Update(InferenceJob inferenceJob, InferenceJobStatus status);
+        /// <param name="job"><see cref="Nvidia.Clara.DicomAdapter.API.InferenceJob" /></param>
+        Task Add(InferenceJob job);
 
         /// <summary>
         /// <c>Take</c> returns the next pending request for submission.
@@ -54,6 +46,14 @@ namespace Nvidia.Clara.DicomAdapter.API
         /// <param name="cancellationToken">cancellation token used to cancel the action.</param>
         /// <returns><see cref="Nvidia.Clara.DicomAdapter.API.InferenceJob"/></returns>
         Task<InferenceJob> Take(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Transition a job to the next processing state.
+        /// </summary>
+        /// <param name="job"><see cref="Nvidia.Clara.DicomAdapter.API.InferenceJob" /></param>
+        /// <param name="status">Status of the request.</param>
+        /// <param name="cancellationToken">cancellation token used to cancel the action.</param>
+        Task<InferenceJob> TransitionState(InferenceJob job, InferenceJobStatus status, CancellationToken cancellationToken);
     }
 
     /// <summary>

--- a/src/API/InferenceJob.cs
+++ b/src/API/InferenceJob.cs
@@ -17,6 +17,7 @@
 
 using Ardalis.GuardClauses;
 using Newtonsoft.Json;
+using Nvidia.Clara.Platform;
 using System;
 using System.Collections.Generic;
 
@@ -37,7 +38,15 @@ namespace Nvidia.Clara.DicomAdapter.API
     public enum InferenceJobState
     {
         Queued,
-        InProcess,
+        Creating,
+        Created,
+        MetadataUploading,
+        MetadataUploaded,
+        PayloadUploading,
+        PayloadUploaded,
+        Starting,
+        Completed,
+        Faulted
     }
 
     /// <summary>
@@ -47,26 +56,29 @@ namespace Nvidia.Clara.DicomAdapter.API
     public class InferenceJob : Job
     {
         public Guid InferenceJobId { get; set; } = Guid.NewGuid();
-        public string JobPayloadsStoragePath { get; set; }
+        public string PipelineId { get; set; }
+        public string JobPayloadsStoragePath { get; private set; }
         public int TryCount { get; set; } = 0;
         public InferenceJobState State { get; set; } = InferenceJobState.Queued;
-
+        public DateTime LastUpdate { get; set; } = DateTime.MinValue;
+        public string JobName { get; set; }
+        public JobPriority Priority { get; set; }
+        public string Source { get; set; }
+        
         [JsonIgnore]
         public IList<InstanceStorageInfo> Instances { get; set; }
 
-        public InferenceJob(string jobPayloadsStoragePath, Job job)
+        public InferenceJob()
         {
-            Guard.Against.NullOrWhiteSpace(jobPayloadsStoragePath, nameof(jobPayloadsStoragePath));
-            Guard.Against.Null(job, nameof(job));
-
-            JobPayloadsStoragePath = jobPayloadsStoragePath;
-            JobId = job.JobId;
-            PayloadId = job.PayloadId;
+            JobId = Guid.NewGuid().ToString("N");
+            PayloadId = Guid.NewGuid().ToString("N");
         }
-
-        [JsonConstructor]
-        private InferenceJob()
+        
+        public void SetStoragePath(string targetStoragePath)
         {
+            Guard.Against.NullOrWhiteSpace(targetStoragePath, nameof(targetStoragePath));
+
+            JobPayloadsStoragePath = targetStoragePath;
         }
     }
 }

--- a/src/API/InferenceJob.cs
+++ b/src/API/InferenceJob.cs
@@ -64,7 +64,7 @@ namespace Nvidia.Clara.DicomAdapter.API
         public string JobName { get; set; }
         public JobPriority Priority { get; set; }
         public string Source { get; set; }
-        
+
         [JsonIgnore]
         public IList<InstanceStorageInfo> Instances { get; set; }
 
@@ -72,8 +72,9 @@ namespace Nvidia.Clara.DicomAdapter.API
         {
             JobId = Guid.NewGuid().ToString("N");
             PayloadId = Guid.NewGuid().ToString("N");
+            Instances = new List<InstanceStorageInfo>();
         }
-        
+
         public void SetStoragePath(string targetStoragePath)
         {
             Guard.Against.NullOrWhiteSpace(targetStoragePath, nameof(targetStoragePath));

--- a/src/API/InferenceJob.cs
+++ b/src/API/InferenceJob.cs
@@ -17,6 +17,7 @@
 
 using Ardalis.GuardClauses;
 using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 
 namespace Nvidia.Clara.DicomAdapter.API
@@ -45,6 +46,7 @@ namespace Nvidia.Clara.DicomAdapter.API
     /// </summary>
     public class InferenceJob : Job
     {
+        public Guid InferenceJobId { get; set; } = Guid.NewGuid();
         public string JobPayloadsStoragePath { get; set; }
         public int TryCount { get; set; } = 0;
         public InferenceJobState State { get; set; } = InferenceJobState.Queued;

--- a/src/API/JobProcessorBase.cs
+++ b/src/API/JobProcessorBase.cs
@@ -88,14 +88,15 @@ namespace Nvidia.Clara.DicomAdapter.API
 
             _logger.Log(LogLevel.Information, "Queueing a new job '{0}' with pipeline '{1}', priority={2}, instance count={3}", jobName, pipelineId, jobPriority, instances.Count);
 
-            var metadata = new JobMetadataBuilder();
-            metadata.AddSourceName($"{AeTitle} ({Name})");
-
-            var job = await _jobsApi.Create(pipelineId, jobName, jobPriority, metadata);
-            using (_logger.BeginScope(new LogginDataDictionary<string, object> { { "JobId", job.JobId }, { "PayloadId", job.PayloadId } }))
+            var job = new InferenceJob()
             {
-                await _jobStore.Add(job, jobName, instances);
-            }
+                JobName = jobName,
+                PipelineId = pipelineId,
+                Priority = jobPriority,
+                Source = $"{AeTitle} ({Name})",
+                Instances = instances
+            };
+            await _jobStore.Add(job);
         }
 
         protected void RemoveInstances(List<InstanceStorageInfo> instances)

--- a/src/API/JobProcessorBase.cs
+++ b/src/API/JobProcessorBase.cs
@@ -43,7 +43,6 @@ namespace Nvidia.Clara.DicomAdapter.API
     {
         private readonly IInstanceStoredNotificationService _instanceStoredNotificationService;
         private readonly ILogger _logger;
-        private readonly IJobs _jobsApi;
         private readonly IJobRepository _jobStore;
         private readonly IInstanceCleanupQueue _cleanupQueue;
         private bool _disposed = false;
@@ -56,7 +55,6 @@ namespace Nvidia.Clara.DicomAdapter.API
         public JobProcessorBase(
             IInstanceStoredNotificationService instanceStoredNotificationService,
             ILoggerFactory loggerFactory,
-            IJobs jobsApi,
             IJobRepository jobStore,
             IInstanceCleanupQueue cleanupQueue,
             CancellationToken cancellationToken)
@@ -68,7 +66,6 @@ namespace Nvidia.Clara.DicomAdapter.API
 
             _instanceStoredNotificationService = instanceStoredNotificationService ?? throw new ArgumentNullException(nameof(instanceStoredNotificationService));
             _logger = loggerFactory.CreateLogger<JobProcessorBase>();
-            _jobsApi = jobsApi ?? throw new ArgumentNullException(nameof(jobsApi));
             _jobStore = jobStore ?? throw new ArgumentNullException(nameof(jobStore));
             _cleanupQueue = cleanupQueue ?? throw new ArgumentNullException(nameof(cleanupQueue));
             CancellationToken = cancellationToken;

--- a/src/Configuration/PlatformConfiguration.cs
+++ b/src/Configuration/PlatformConfiguration.cs
@@ -58,11 +58,11 @@ namespace Nvidia.Clara.DicomAdapter.Configuration
         public int MaxRetries { get; set; } = 3;
 
         /// <summary>
-        /// Gets or sets number of seconds to wait before performing a follow=up request.
+        /// Gets or sets number of seconds to wait before attempting to retry.
         /// </summary>
         /// <value></value>
         [JsonProperty(PropertyName = "retryDelaySeconds")]
-        public int RetryDelaySeconds { get; set; } = 60;
+        public int RetryDelaySeconds { get; set; } = 180;
 
         public PlatformConfiguration()
         {

--- a/src/Configuration/PlatformConfiguration.cs
+++ b/src/Configuration/PlatformConfiguration.cs
@@ -44,11 +44,25 @@ namespace Nvidia.Clara.DicomAdapter.Configuration
         public bool UploadMetadata { get; set; } = false;
 
         /// <summary>
-        /// Gets or set a list of DICOM tags to be extracted and attached to the job triggered with the Clara Jobs Service.
+        /// Gets or sets a list of DICOM tags to be extracted and attached to the job triggered with the Clara Jobs Service.
         /// </summary>
         /// <value></value>
         [JsonProperty(PropertyName = "metadataDicomSource")]
         public List<string> MetadataDicomSource { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of retries to be performed when an execution attempt fails to connect to Clara Platform.
+        /// </summary>
+        /// <value></value>
+        [JsonProperty(PropertyName = "maxRetries")]
+        public int MaxRetries { get; set; } = 3;
+
+        /// <summary>
+        /// Gets or sets number of seconds to wait before performing a follow=up request.
+        /// </summary>
+        /// <value></value>
+        [JsonProperty(PropertyName = "retryDelaySeconds")]
+        public int RetryDelaySeconds { get; set; } = 60;
 
         public PlatformConfiguration()
         {

--- a/src/Database/InferenceJobConfiguration.cs
+++ b/src/Database/InferenceJobConfiguration.cs
@@ -31,6 +31,11 @@ namespace Nvidia.Clara.DicomAdapter.Database
             builder.Property(f => f.JobPayloadsStoragePath).IsRequired();
             builder.Property(f => f.TryCount).IsRequired();
             builder.Property(f => f.State).IsRequired();
+            builder.Property(f => f.LastUpdate).IsRequired();
+            builder.Property(f => f.JobName).IsRequired();
+            builder.Property(f => f.PipelineId).IsRequired();
+            builder.Property(f => f.Priority).IsRequired();
+            builder.Property(f => f.Source).IsRequired();
 
             builder.Ignore(f => f.Instances);
         }

--- a/src/Database/InferenceJobConfiguration.cs
+++ b/src/Database/InferenceJobConfiguration.cs
@@ -24,8 +24,9 @@ namespace Nvidia.Clara.DicomAdapter.Database
     {
         public void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<InferenceJob> builder)
         {
-            builder.HasKey(f => f.JobId);
+            builder.HasKey(f => f.InferenceJobId);
 
+            builder.Property(f => f.JobId);
             builder.Property(f => f.PayloadId).IsRequired();
             builder.Property(f => f.JobPayloadsStoragePath).IsRequired();
             builder.Property(f => f.TryCount).IsRequired();

--- a/src/Database/Migrations/20210420185743_InitialCreate.Designer.cs
+++ b/src/Database/Migrations/20210420185743_InitialCreate.Designer.cs
@@ -9,7 +9,7 @@ using Nvidia.Clara.DicomAdapter.Database;
 namespace Nvidia.Clara.DicomAdapter.Database.Migrations
 {
     [DbContext(typeof(DicomAdapterContext))]
-    [Migration("20210420162859_InitialCreate")]
+    [Migration("20210420185743_InitialCreate")]
     partial class InitialCreate
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -70,6 +70,10 @@ namespace Nvidia.Clara.DicomAdapter.Database.Migrations
 
             modelBuilder.Entity("Nvidia.Clara.DicomAdapter.API.InferenceJob", b =>
                 {
+                    b.Property<Guid>("InferenceJobId")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TEXT");
+
                     b.Property<string>("JobId")
                         .HasColumnType("TEXT");
 
@@ -87,7 +91,7 @@ namespace Nvidia.Clara.DicomAdapter.Database.Migrations
                     b.Property<int>("TryCount")
                         .HasColumnType("INTEGER");
 
-                    b.HasKey("JobId");
+                    b.HasKey("InferenceJobId");
 
                     b.ToTable("InferenceJobs");
                 });
@@ -97,7 +101,7 @@ namespace Nvidia.Clara.DicomAdapter.Database.Migrations
                     b.Property<Guid>("InferenceRequestId")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("TEXT")
-                        .HasDefaultValue(new Guid("b932b86a-564b-4cfb-8590-2e98be3aaaf5"));
+                        .HasDefaultValue(new Guid("14580e42-745d-4b76-a24c-24570d5f6568"));
 
                     b.Property<string>("InputMetadata")
                         .HasColumnType("TEXT");

--- a/src/Database/Migrations/20210420185743_InitialCreate.cs
+++ b/src/Database/Migrations/20210420185743_InitialCreate.cs
@@ -41,7 +41,8 @@ namespace Nvidia.Clara.DicomAdapter.Database.Migrations
                 name: "InferenceJobs",
                 columns: table => new
                 {
-                    JobId = table.Column<string>(nullable: false),
+                    InferenceJobId = table.Column<Guid>(nullable: false),
+                    JobId = table.Column<string>(nullable: true),
                     PayloadId = table.Column<string>(nullable: false),
                     JobPayloadsStoragePath = table.Column<string>(nullable: false),
                     TryCount = table.Column<int>(nullable: false),
@@ -49,14 +50,14 @@ namespace Nvidia.Clara.DicomAdapter.Database.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_InferenceJobs", x => x.JobId);
+                    table.PrimaryKey("PK_InferenceJobs", x => x.InferenceJobId);
                 });
 
             migrationBuilder.CreateTable(
                 name: "InferenceRequests",
                 columns: table => new
                 {
-                    InferenceRequestId = table.Column<Guid>(nullable: false, defaultValue: new Guid("b932b86a-564b-4cfb-8590-2e98be3aaaf5")),
+                    InferenceRequestId = table.Column<Guid>(nullable: false, defaultValue: new Guid("14580e42-745d-4b76-a24c-24570d5f6568")),
                     TransactionId = table.Column<string>(nullable: false),
                     Priority = table.Column<byte>(nullable: false),
                     InputMetadata = table.Column<string>(nullable: true),

--- a/src/Database/Migrations/20210420194021_202104-Scheduler.Designer.cs
+++ b/src/Database/Migrations/20210420194021_202104-Scheduler.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nvidia.Clara.DicomAdapter.Database;
 
 namespace Nvidia.Clara.DicomAdapter.Database.Migrations
 {
     [DbContext(typeof(DicomAdapterContext))]
-    partial class DicomAdapterContextModelSnapshot : ModelSnapshot
+    [Migration("20210420194021_202104-Scheduler")]
+    partial class _202104Scheduler
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Database/Migrations/20210420194021_202104-Scheduler.cs
+++ b/src/Database/Migrations/20210420194021_202104-Scheduler.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Nvidia.Clara.DicomAdapter.Database.Migrations
+{
+    public partial class _202104Scheduler : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "JobName",
+                table: "InferenceJobs",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastUpdate",
+                table: "InferenceJobs",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<string>(
+                name: "PipelineId",
+                table: "InferenceJobs",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<int>(
+                name: "Priority",
+                table: "InferenceJobs",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Source",
+                table: "InferenceJobs",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "JobName",
+                table: "InferenceJobs");
+
+            migrationBuilder.DropColumn(
+                name: "LastUpdate",
+                table: "InferenceJobs");
+
+            migrationBuilder.DropColumn(
+                name: "PipelineId",
+                table: "InferenceJobs");
+
+            migrationBuilder.DropColumn(
+                name: "Priority",
+                table: "InferenceJobs");
+
+            migrationBuilder.DropColumn(
+                name: "Source",
+                table: "InferenceJobs");
+        }
+    }
+}

--- a/src/Database/Migrations/DicomAdapterContextModelSnapshot.cs
+++ b/src/Database/Migrations/DicomAdapterContextModelSnapshot.cs
@@ -68,6 +68,10 @@ namespace Nvidia.Clara.DicomAdapter.Database.Migrations
 
             modelBuilder.Entity("Nvidia.Clara.DicomAdapter.API.InferenceJob", b =>
                 {
+                    b.Property<Guid>("InferenceJobId")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TEXT");
+
                     b.Property<string>("JobId")
                         .HasColumnType("TEXT");
 
@@ -85,7 +89,7 @@ namespace Nvidia.Clara.DicomAdapter.Database.Migrations
                     b.Property<int>("TryCount")
                         .HasColumnType("INTEGER");
 
-                    b.HasKey("JobId");
+                    b.HasKey("InferenceJobId");
 
                     b.ToTable("InferenceJobs");
                 });
@@ -95,7 +99,7 @@ namespace Nvidia.Clara.DicomAdapter.Database.Migrations
                     b.Property<Guid>("InferenceRequestId")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("TEXT")
-                        .HasDefaultValue(new Guid("b932b86a-564b-4cfb-8590-2e98be3aaaf5"));
+                        .HasDefaultValue(new Guid("14580e42-745d-4b76-a24c-24570d5f6568"));
 
                     b.Property<string>("InputMetadata")
                         .HasColumnType("TEXT");

--- a/src/Server/Common/InsufficientStorageAvailableException .cs
+++ b/src/Server/Common/InsufficientStorageAvailableException .cs
@@ -16,7 +16,6 @@
  */
 
 using System;
-using System.Runtime.Serialization;
 
 namespace Nvidia.Clara.DicomAdapter.Server.Common
 {
@@ -28,14 +27,6 @@ namespace Nvidia.Clara.DicomAdapter.Server.Common
         }
 
         public InsufficientStorageAvailableException(string message) : base(message)
-        {
-        }
-
-        public InsufficientStorageAvailableException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        protected InsufficientStorageAvailableException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/src/Server/Processors/AeTitleJobProcessor.cs
+++ b/src/Server/Processors/AeTitleJobProcessor.cs
@@ -101,11 +101,10 @@ namespace Nvidia.Clara.DicomAdapter.Server.Processors
             ClaraApplicationEntity configuration,
             IInstanceStoredNotificationService instanceStoredNotificationService,
             ILoggerFactory loggerFactory,
-            IJobs jobsApi,
             IJobRepository jobStore,
             IInstanceCleanupQueue cleanupQueue,
             IDicomToolkit dicomToolkit,
-            CancellationToken cancellationToken) : base(instanceStoredNotificationService, loggerFactory, jobsApi, jobStore, cleanupQueue, cancellationToken)
+            CancellationToken cancellationToken) : base(instanceStoredNotificationService, loggerFactory, jobStore, cleanupQueue, cancellationToken)
         {
             if (loggerFactory is null)
             {

--- a/src/Server/Repositories/ClaraJobRepository.cs
+++ b/src/Server/Repositories/ClaraJobRepository.cs
@@ -22,11 +22,13 @@ using Nvidia.Clara.DicomAdapter.API;
 using Nvidia.Clara.DicomAdapter.API.Rest;
 using Nvidia.Clara.DicomAdapter.Common;
 using Nvidia.Clara.DicomAdapter.Configuration;
+using Nvidia.Clara.Platform;
 using Polly;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -65,21 +67,17 @@ namespace Nvidia.Clara.DicomAdapter.Server.Repositories
         /// Adds a new job to the queue (database). A copy of the payload is made to support multiple pipelines per AE Title.
         /// </summary>
         /// <param name="job">Job to be queued.</param>
-        /// <param name="jobName">Name of the job.</param>
-        /// <param name="instances">DICOM instances associated with the job.</param>
-        public async Task Add(Job job, string jobName, IList<InstanceStorageInfo> instances)
+        public async Task Add(InferenceJob job)
         {
             Guard.Against.Null(job, nameof(job));
-            Guard.Against.Null(jobName, nameof(jobName));
-            Guard.Against.NullOrEmpty(instances, nameof(instances));
 
             using (_logger.BeginScope(new LogginDataDictionary<string, object> { { "JobId", job.JobId }, { "PayloadId", job.PayloadId } }))
             {
-                var inferenceJob = CreateInferenceJob(job, jobName, instances);
+                ConfigureStoragePath(job);
 
                 // Makes a copy of the payload to support multiple pipelines per AE Title.
                 // Future, consider use of persisted payloads.
-                MakeACopyOfPayload(inferenceJob);
+                MakeACopyOfPayload(job);
 
                 await Policy
                     .Handle<Exception>()
@@ -88,11 +86,11 @@ namespace Nvidia.Clara.DicomAdapter.Server.Repositories
                         retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
                         (exception, timeSpan, retryCount, context) =>
                     {
-                        _logger.Log(LogLevel.Error, exception, $"Error saving inference request. Waiting {timeSpan} before next retry. Retry attempt {retryCount}.");
+                        _logger.Log(LogLevel.Error, exception, $"Error saving inference job. Waiting {timeSpan} before next retry. Retry attempt {retryCount}.");
                     })
                     .ExecuteAsync(async () =>
                     {
-                        await _inferenceJobRepository.AddAsync(inferenceJob);
+                        await _inferenceJobRepository.AddAsync(job);
                         await _inferenceJobRepository.SaveChangesAsync();
                     })
                     .ConfigureAwait(false);
@@ -106,36 +104,43 @@ namespace Nvidia.Clara.DicomAdapter.Server.Repositories
             using var loggerScope = _logger.BeginScope(new LogginDataDictionary<string, object> { { "JobId", inferenceJob.JobId }, { "PayloadId", inferenceJob.PayloadId } });
             if (status == InferenceJobStatus.Success)
             {
-                _logger.Log(LogLevel.Information, $"Removing job as completed.");
-                await Delete(inferenceJob);
+                _logger.Log(LogLevel.Information, $"Marking inference job as completed.");
+                inferenceJob.State = InferenceJobState.Completed;
             }
             else
             {
-                if (++inferenceJob.TryCount > MaxRetryLimit)
-                {
-                    _logger.Log(LogLevel.Information, $"Exceeded maximum job submission retries; removing job from job store.");
-                    await Delete(inferenceJob);
-                }
-                else
-                {
-                    _logger.Log(LogLevel.Debug, $"Adding job back to job store for retry.");
-                    inferenceJob.State = InferenceJobState.Queued;
-                    await UpdateInferenceJob(inferenceJob);
-                }
             }
+            inferenceJob.LastUpdate = DateTime.UtcNow;
+            await UpdateInferenceJob(inferenceJob);
         }
 
         public async Task<InferenceJob> Take(CancellationToken cancellationToken)
         {
             while (!cancellationToken.IsCancellationRequested)
             {
-                var request = _inferenceJobRepository.FirstOrDefault(p => p.State == InferenceJobState.Queued);
+                var request = _inferenceJobRepository
+                                .AsQueryable()
+                                .Where(p => (p.State == InferenceJobState.Queued ||
+                                    p.State == InferenceJobState.Created ||
+                                    p.State == InferenceJobState.PayloadUploaded ||
+                                    p.State == InferenceJobState.MetadataUploaded) &&
+                                    p.LastUpdate < DateTime.UtcNow.AddSeconds(-_configuration.Value.Services.Platform.RetryDelaySeconds))
+                                .OrderBy(p => p.LastUpdate)
+                                .FirstOrDefault();
 
                 if (!(request is null))
                 {
                     using var loggerScope = _logger.BeginScope(new LogginDataDictionary<string, object> { { "JobId", request.JobId }, { "PayloadId", request.PayloadId } });
-                    request.State = InferenceJobState.InProcess;
-                    _logger.Log(LogLevel.Debug, $"Updating request {request.JobId} to InProgress.");
+                    var originalState = request.State;
+                    request.State = request.State switch
+                    {
+                        InferenceJobState.Queued => InferenceJobState.Creating,
+                        InferenceJobState.Created => InferenceJobState.MetadataUploading,
+                        InferenceJobState.MetadataUploaded => InferenceJobState.PayloadUploading,
+                        InferenceJobState.PayloadUploaded => InferenceJobState.Starting,
+                        _ => throw new ApplicationException($"unsupported job state {request.State}")
+                    };
+                    _logger.Log(LogLevel.Information, $"Updating inference job {request.JobId} from {originalState } to {request.State}. (Attempt #{request.TryCount + 1}).");
                     await UpdateInferenceJob(request, cancellationToken);
                     return request;
                 }
@@ -145,9 +150,56 @@ namespace Nvidia.Clara.DicomAdapter.Server.Repositories
             throw new OperationCanceledException("Cancellation requested.");
         }
 
-        private async Task UpdateInferenceJob(InferenceJob request, CancellationToken cancellationToken = default)
+        public async Task<InferenceJob> TransitionState(InferenceJob job, InferenceJobStatus status, CancellationToken cancellationToken = default)
         {
-            Guard.Against.Null(request, nameof(request));
+            Guard.Against.Null(job, nameof(job));
+
+            if (status == InferenceJobStatus.Success)
+            {
+                var originalState = job.State;
+                job.State = job.State switch
+                {
+                    InferenceJobState.Creating => InferenceJobState.Created,
+                    InferenceJobState.MetadataUploading => InferenceJobState.MetadataUploaded,
+                    InferenceJobState.PayloadUploading => InferenceJobState.PayloadUploaded,
+                    InferenceJobState.Starting => InferenceJobState.Completed,
+                    _ => throw new ApplicationException($"unsupported job state {job.State}")
+                };
+                job.LastUpdate = DateTime.UtcNow;
+                job.TryCount = 0;
+
+                _logger.Log(LogLevel.Information, $"Updating inference job state {job.JobId} from {originalState } to {job.State}.");
+                await UpdateInferenceJob(job, cancellationToken);
+            }
+            else
+            {
+                if (++job.TryCount > _configuration.Value.Services.Platform.MaxRetries)
+                {
+                    _logger.Log(LogLevel.Information, $"Exceeded maximum job submission retries.");
+                    job.State = InferenceJobState.Faulted;
+                }
+                else
+                {
+                    job.State = job.State switch
+                    {
+                        InferenceJobState.Creating => InferenceJobState.Queued,
+                        InferenceJobState.MetadataUploading => InferenceJobState.Created,
+                        InferenceJobState.PayloadUploading => InferenceJobState.MetadataUploaded,
+                        InferenceJobState.Starting => InferenceJobState.PayloadUploaded,
+                        _ => throw new ApplicationException($"unsupported job state {job.State}")
+                    };
+                    _logger.Log(LogLevel.Information, $"Putting inference job {job.JobId} back to {job.State} state for retry.");
+                }
+                job.LastUpdate = DateTime.UtcNow;
+                await UpdateInferenceJob(job, cancellationToken);
+            }
+
+            return job;
+        }
+
+        private async Task UpdateInferenceJob(InferenceJob job, CancellationToken cancellationToken = default)
+        {
+            Guard.Against.Null(job, nameof(job));
 
             await Policy
                  .Handle<Exception>()
@@ -167,17 +219,15 @@ namespace Nvidia.Clara.DicomAdapter.Server.Repositories
                  .ConfigureAwait(false);
         }
 
-        private InferenceJob CreateInferenceJob(Job job, string jobName, IList<InstanceStorageInfo> instances)
+        private void ConfigureStoragePath(InferenceJob job)
         {
             Guard.Against.Null(job, nameof(job));
-            Guard.Against.Null(jobName, nameof(jobName));
-            Guard.Against.Null(instances, nameof(instances));
 
             var targetStoragePath = string.Empty; ;
             if (_fileSystem.Directory.TryGenerateDirectory(_fileSystem.Path.Combine(_configuration.Value.Storage.TemporaryDataDirFullPath, "jobs", $"{job.JobId}"), out targetStoragePath))
             {
                 _logger.Log(LogLevel.Information, $"Job payloads directory set to {targetStoragePath}");
-                return new InferenceJob(targetStoragePath, job) { Instances = instances };
+                job.SetStoragePath(targetStoragePath);
             }
             else
             {
@@ -223,29 +273,6 @@ namespace Nvidia.Clara.DicomAdapter.Server.Repositories
 
             _logger.Log(
                 files.Count == 0 ? LogLevel.Information : LogLevel.Warning, $"Copied {request.Instances.Count - files.Count:D} files to '{request.JobPayloadsStoragePath}'.");
-        }
-
-        private async Task Delete(InferenceJob request)
-        {
-            Guard.Against.Null(request, nameof(request));
-
-            await Policy
-                .Handle<Exception>()
-                .WaitAndRetryAsync(
-                    3,
-                    retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
-                    (exception, timeSpan, retryCount, context) =>
-                    {
-                        _logger.Log(LogLevel.Error, exception, $"Failed to delete job. Waiting {timeSpan} before next retry. Retry attempt {retryCount}.");
-                    })
-                .ExecuteAsync(async () =>
-                {
-                    _inferenceJobRepository.Remove(request);
-                    await _inferenceJobRepository.SaveChangesAsync();
-                })
-                .ConfigureAwait(false);
-
-            _logger.Log(LogLevel.Information, $"Job removed from job store.");
         }
     }
 }

--- a/src/Server/Repositories/ClaraJobRepository.cs
+++ b/src/Server/Repositories/ClaraJobRepository.cs
@@ -146,6 +146,7 @@ namespace Nvidia.Clara.DicomAdapter.Server.Repositories
                     _ => throw new ApplicationException($"unsupported job state {job.State}")
                 };
                 job.TryCount = 0;
+                job.LastUpdate = DateTime.MinValue;
 
                 _logger.Log(LogLevel.Information, $"Updating inference job state {job.JobId} from {originalState } to {job.State}.");
                 await UpdateInferenceJob(job, cancellationToken);
@@ -154,7 +155,7 @@ namespace Nvidia.Clara.DicomAdapter.Server.Repositories
             {
                 if (++job.TryCount > _configuration.Value.Services.Platform.MaxRetries)
                 {
-                    _logger.Log(LogLevel.Warning, $"Exceeded maximum job submission retries.");
+                    _logger.Log(LogLevel.Warning, $"Job {job.JobId} exceeded maximum number of retries.");
                     job.State = InferenceJobState.Faulted;
                 }
                 else

--- a/src/Server/Repositories/ClaraJobsApi.cs
+++ b/src/Server/Repositories/ClaraJobsApi.cs
@@ -54,7 +54,7 @@ namespace Nvidia.Clara.DicomAdapter.Server.Repositories
         {
             return await Policy.Handle<Exception>()
                 .WaitAndRetryAsync(
-                    3,
+                    1,
                     retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
                     (exception, retryCount, context) =>
                     {
@@ -78,7 +78,7 @@ namespace Nvidia.Clara.DicomAdapter.Server.Repositories
         {
             await Policy.Handle<Exception>()
                 .WaitAndRetryAsync(
-                    3,
+                    1,
                     retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
                     (exception, retryCount, context) =>
                     {
@@ -101,7 +101,7 @@ namespace Nvidia.Clara.DicomAdapter.Server.Repositories
         {
             await Policy.Handle<Exception>()
                 .WaitAndRetryAsync(
-                    3,
+                    1,
                     retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
                     (exception, retryCount, context) =>
                     {
@@ -122,7 +122,7 @@ namespace Nvidia.Clara.DicomAdapter.Server.Repositories
         {
             return await Policy.Handle<Exception>()
                 .WaitAndRetryAsync(
-                    3,
+                    1,
                     retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
                     (exception, retryCount, context) =>
                     {

--- a/src/Server/Services/Export/DicomWebExportService.cs
+++ b/src/Server/Services/Export/DicomWebExportService.cs
@@ -59,15 +59,16 @@ namespace Nvidia.Clara.DicomAdapter.Server.Services.Export
             IStorageInfoProvider storageInfoProvider)
             : base(logger, payloadsApi, resultsService, dicomAdapterConfiguration, storageInfoProvider)
         {
+            _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+            _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+            _inferenceRequestStore = inferenceRequestStore ?? throw new ArgumentNullException(nameof(inferenceRequestStore));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
             if (dicomAdapterConfiguration is null)
             {
                 throw new ArgumentNullException(nameof(dicomAdapterConfiguration));
             }
 
-            _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
-            _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
-            _inferenceRequestStore = inferenceRequestStore ?? throw new ArgumentNullException(nameof(inferenceRequestStore));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _dataExportConfiguration = dicomAdapterConfiguration.Value.Dicom.Scu.ExportSettings;
 
             Agent = _dataExportConfiguration.Agent;

--- a/src/Server/Services/Export/ExportServiceBase.cs
+++ b/src/Server/Services/Export/ExportServiceBase.cs
@@ -58,14 +58,15 @@ namespace Nvidia.Clara.DicomAdapter.Server.Services.Export
             IOptions<DicomAdapterConfiguration> dicomAdapterConfiguration,
             IStorageInfoProvider storageInfoProvider)
         {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _payloadsApi = payloadsApi ?? throw new ArgumentNullException(nameof(payloadsApi));
+            _resultsService = resultsService ?? throw new ArgumentNullException(nameof(resultsService));
+
             if (dicomAdapterConfiguration is null)
             {
                 throw new ArgumentNullException(nameof(dicomAdapterConfiguration));
             }
 
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _payloadsApi = payloadsApi ?? throw new ArgumentNullException(nameof(payloadsApi));
-            _resultsService = resultsService ?? throw new ArgumentNullException(nameof(resultsService));
             _storageInfoProvider = storageInfoProvider ?? throw new ArgumentNullException(nameof(storageInfoProvider));
             _dataExportConfiguration = dicomAdapterConfiguration.Value.Dicom.Scu.ExportSettings;
         }

--- a/src/Server/Services/Jobs/DataRetrievalService.cs
+++ b/src/Server/Services/Jobs/DataRetrievalService.cs
@@ -191,11 +191,14 @@ namespace Nvidia.Clara.DicomAdapter.Server.Services.Jobs
 
             _logger.Log(LogLevel.Information, $"Queuing a new job '{inferenceRequest.JobName}' with pipeline '{inferenceRequest.Algorithm.PipelineId}', priority={inferenceRequest.ClaraJobPriority}, instance count={instances.Count()}");
             await _jobStore.Add(
-                new Job
+                new InferenceJob
                 {
                     JobId = inferenceRequest.JobId,
-                    PayloadId = inferenceRequest.PayloadId
-                }, inferenceRequest.JobName, instances.ToList());
+                    PayloadId = inferenceRequest.PayloadId,
+                    JobName = inferenceRequest.JobName,
+                    Instances = instances.ToList(),
+                    State = InferenceJobState.Created
+                });
         }
 
         #region Data Retrieval

--- a/src/Server/Test/Unit/Processors/AeTitleJobProcessorTest.cs
+++ b/src/Server/Test/Unit/Processors/AeTitleJobProcessorTest.cs
@@ -180,7 +180,7 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
         public void ProcessJobs_ShallRetryUpTo3Times()
         {
             var countDownEvent = new CountdownEvent(3);
-            _jobsApi.Setup(p => p.Create(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<JobPriority>(), It.IsAny<Dictionary<string,string>>()))
+            _jobStore.Setup(p => p.Add(It.IsAny<InferenceJob>()))
                 .Callback(() =>
                 {
                     countDownEvent.Signal();
@@ -197,7 +197,7 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
             _notificationService.NewInstanceStored(_instances.First());
             Assert.True(countDownEvent.Wait(7000));
 
-            _jobsApi.Verify(p => p.Create(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<JobPriority>(), It.IsAny<Dictionary<string,string>>()), Times.Exactly(3));
+            _jobStore.Verify(p => p.Add(It.IsAny<InferenceJob>()), Times.Exactly(3));
             _logger.VerifyLogging($"Failed to submit job, will retry later: PatientId={_instances.First().PatientId}, Study={_instances.First().StudyInstanceUid}", LogLevel.Information, Times.AtLeast(1));
             _logger.VerifyLogging($"Failed to submit job after 3 retries: PatientId={_instances.First().PatientId}, Study={_instances.First().StudyInstanceUid}", LogLevel.Error, Times.Once());
         }

--- a/src/Server/Test/Unit/Processors/MockJobProcessor.cs
+++ b/src/Server/Test/Unit/Processors/MockJobProcessor.cs
@@ -32,10 +32,9 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
             ClaraApplicationEntity configuration,
             IInstanceStoredNotificationService instanceStoredNotificationService,
             ILoggerFactory loggerFactory,
-            IJobs jobsApi,
             IJobRepository jobStore,
             IInstanceCleanupQueue cleanupQueue,
-            CancellationToken cancellationToken) : base(instanceStoredNotificationService, loggerFactory, jobsApi, jobStore, cleanupQueue, cancellationToken)
+            CancellationToken cancellationToken) : base(instanceStoredNotificationService, loggerFactory, jobStore, cleanupQueue, cancellationToken)
         {
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         }

--- a/src/Server/Test/Unit/Repositories/ClaraJobRepositoryTest.cs
+++ b/src/Server/Test/Unit/Repositories/ClaraJobRepositoryTest.cs
@@ -288,7 +288,7 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
             Assert.Equal(job, result);
             Assert.Equal(InferenceJobState.Faulted, result.State);
             Assert.Equal(4, result.TryCount);
-            _logger.VerifyLoggingMessageBeginsWith($"Exceeded maximum job submission retries.", LogLevel.Warning, Times.Once());
+            _logger.VerifyLoggingMessageBeginsWith($"Job {job.JobId} exceeded maximum number of retries.", LogLevel.Warning, Times.Once());
             _inferenceJobRepository.Verify(p => p.SaveChangesAsync(cancellationSource.Token), Times.Once());
         }
     }

--- a/src/Server/Test/Unit/Repositories/ClaraJobsApiTest.cs
+++ b/src/Server/Test/Unit/Repositories/ClaraJobsApiTest.cs
@@ -59,7 +59,7 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
                 p => p.CreateJob(It.IsAny<PipelineId>(), It.IsAny<string>(), JobPriority.Higher, It.IsAny<Dictionary<string, string>>()),
                 Times.Never());
 
-            mockLogger.VerifyLogging(LogLevel.Error, Times.Exactly(3));
+            mockLogger.VerifyLogging(LogLevel.Error, Times.Exactly(1));
         }
 
         [RetryFact(DisplayName = "Create shall respect retry policy on failures")]
@@ -81,9 +81,9 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
             Assert.IsType<RpcException>(exception.InnerException);
             mockClient.Verify(
                 p => p.CreateJob(It.IsAny<PipelineId>(), It.IsAny<string>(), JobPriority.Lower, It.IsAny<Dictionary<string, string>>()),
-                Times.Exactly(4));
+                Times.Exactly(2));
 
-            mockLogger.VerifyLogging(LogLevel.Error, Times.Exactly(3));
+            mockLogger.VerifyLogging(LogLevel.Error, Times.Exactly(1));
         }
 
         [RetryFact(DisplayName = "Create shall return a job")]
@@ -152,7 +152,7 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
                 p => p.StartJob(It.IsAny<JobId>(), It.IsAny<List<KeyValuePair<string, string>>>()),
                 Times.Never());
 
-            mockLogger.VerifyLogging(LogLevel.Error, Times.Exactly(3));
+            mockLogger.VerifyLogging(LogLevel.Error, Times.Exactly(1));
         }
 
         [RetryFact(DisplayName = "Start shall respect retry policy on failures")]
@@ -180,9 +180,9 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
             Assert.IsType<RpcException>(exception.InnerException);
             mockClient.Verify(
                 p => p.StartJob(It.IsAny<JobId>(), It.IsAny<List<KeyValuePair<string, string>>>()),
-                Times.Exactly(4));
+                Times.Exactly(2));
 
-            mockLogger.VerifyLogging(LogLevel.Error, Times.Exactly(3));
+            mockLogger.VerifyLogging(LogLevel.Error, Times.Exactly(1));
         }
 
         [RetryFact(DisplayName = "Start shall be able to start a job successfully")]
@@ -244,7 +244,7 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
                 p => p.GetStatus(It.IsAny<JobId>()),
                 Times.Never());
 
-            mockLogger.VerifyLogging(LogLevel.Error, Times.Exactly(3));
+            mockLogger.VerifyLogging(LogLevel.Error, Times.Exactly(1));
         }
 
         [RetryFact(DisplayName = "Status shall respect retry policy on failures")]
@@ -268,9 +268,9 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
             Assert.IsType<RpcException>(exception.InnerException);
             mockClient.Verify(
                 p => p.GetStatus(It.IsAny<JobId>()),
-                Times.Exactly(4));
+                Times.Exactly(2));
 
-            mockLogger.VerifyLogging(LogLevel.Error, Times.Exactly(3));
+            mockLogger.VerifyLogging(LogLevel.Error, Times.Exactly(1));
         }
 
         [RetryFact(DisplayName = "Status shall be able to retrieve job status successfully")]
@@ -319,7 +319,7 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
             var mockClient = new Mock<IJobsClient>();
             var mockLogger = new Mock<ILogger<ClaraJobsApi>>();
 
-            mockClient.Setup(p => p.AddMetadata(It.IsAny<JobId>(), It.IsAny<Dictionary<string,string>>()));
+            mockClient.Setup(p => p.AddMetadata(It.IsAny<JobId>(), It.IsAny<Dictionary<string, string>>()));
 
             var service = new ClaraJobsApi(mockClient.Object, mockLogger.Object);
 
@@ -339,7 +339,7 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
                 p => p.AddMetadata(It.IsAny<JobId>(), It.IsAny<Dictionary<string, string>>()),
                 Times.Never());
 
-            mockLogger.VerifyLogging(LogLevel.Error, Times.Exactly(3));
+            mockLogger.VerifyLogging(LogLevel.Error, Times.Exactly(1));
         }
 
         [RetryFact(DisplayName = "AddMetadata shall respect retry policy on failures")]
@@ -348,7 +348,7 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
             var mockClient = new Mock<IJobsClient>();
             var mockLogger = new Mock<ILogger<ClaraJobsApi>>();
 
-            mockClient.Setup(p => p.AddMetadata(It.IsAny<JobId>(), It.IsAny<Dictionary<string,string>>()))
+            mockClient.Setup(p => p.AddMetadata(It.IsAny<JobId>(), It.IsAny<Dictionary<string, string>>()))
                 .Throws(new RpcException(Status.DefaultCancelled));
 
             var service = new ClaraJobsApi(mockClient.Object, mockLogger.Object);
@@ -367,9 +367,9 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
             Assert.IsType<RpcException>(exception.InnerException);
             mockClient.Verify(
                 p => p.AddMetadata(It.IsAny<JobId>(), It.IsAny<Dictionary<string, string>>()),
-                Times.Exactly(4));
+                Times.Exactly(2));
 
-            mockLogger.VerifyLogging(LogLevel.Error, Times.Exactly(3));
+            mockLogger.VerifyLogging(LogLevel.Error, Times.Exactly(1));
         }
 
         [RetryFact(DisplayName = "AddMetadata shall be able to add metadata successfully")]
@@ -403,6 +403,6 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
             mockLogger.VerifyLogging(LogLevel.Information, Times.Once());
         }
 
-        #endregion Status
+        #endregion AddMetadata
     }
 }

--- a/src/Server/Test/Unit/Services/Export/DicomWebExportServiceTest.cs
+++ b/src/Server/Test/Unit/Services/Export/DicomWebExportServiceTest.cs
@@ -65,6 +65,19 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
             _cancellationTokenSource = new CancellationTokenSource();
         }
 
+        [Fact(DisplayName = "Constructor - throws on null params")]
+        public void Constructor_ThrowsOnNullParams()
+        {
+            Assert.Throws<ArgumentNullException>(() => new DicomWebExportService(null, null, null, null, null, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new DicomWebExportService(_loggerFactory.Object, null, null, null, null, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new DicomWebExportService(_loggerFactory.Object, _httpClientFactory.Object, null, null, null, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new DicomWebExportService(_loggerFactory.Object, _httpClientFactory.Object, _inferenceRequestStore.Object, null, null, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new DicomWebExportService(_loggerFactory.Object, _httpClientFactory.Object, _inferenceRequestStore.Object, _logger.Object, null, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new DicomWebExportService(_loggerFactory.Object, _httpClientFactory.Object, _inferenceRequestStore.Object, _logger.Object, _payloadsApi.Object, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new DicomWebExportService(_loggerFactory.Object, _httpClientFactory.Object, _inferenceRequestStore.Object, _logger.Object, _payloadsApi.Object, _resultsService.Object, null, null));
+            Assert.Throws<ArgumentNullException>(() => new DicomWebExportService(_loggerFactory.Object, _httpClientFactory.Object, _inferenceRequestStore.Object, _logger.Object, _payloadsApi.Object, _resultsService.Object, _configuration, null));
+        }
+
         [RetryFact(DisplayName = " ExportDataBlockCallback - Returns null if inference request cannot be found")]
         public async Task ExportDataBlockCallback_ReturnsNullIfInferenceRequestCannotBeFound()
         {

--- a/src/Server/Test/Unit/Services/Http/ClaraAeTitleControllerTest.cs
+++ b/src/Server/Test/Unit/Services/Http/ClaraAeTitleControllerTest.cs
@@ -428,10 +428,9 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
             ClaraApplicationEntity configuration,
             IInstanceStoredNotificationService instanceStoredNotificationService,
             ILoggerFactory loggerFactory,
-            IJobs jobsApi,
             IJobRepository jobStore,
             IInstanceCleanupQueue cleanupQueue,
-            CancellationToken cancellationToken) : base(instanceStoredNotificationService, loggerFactory, jobsApi, jobStore, cleanupQueue, cancellationToken)
+            CancellationToken cancellationToken) : base(instanceStoredNotificationService, loggerFactory, jobStore, cleanupQueue, cancellationToken)
         {
         }
 
@@ -451,10 +450,9 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
             ClaraApplicationEntity configuration,
             IInstanceStoredNotificationService instanceStoredNotificationService,
             ILoggerFactory loggerFactory,
-            IJobs jobsApi,
             IJobRepository jobStore,
             IInstanceCleanupQueue cleanupQueue,
-            CancellationToken cancellationToken) : base(instanceStoredNotificationService, loggerFactory, jobsApi, jobStore, cleanupQueue, cancellationToken)
+            CancellationToken cancellationToken) : base(instanceStoredNotificationService, loggerFactory, jobStore, cleanupQueue, cancellationToken)
         {
         }
 

--- a/src/Server/Test/Unit/Services/Job/DataRetrievalServiceTest.cs
+++ b/src/Server/Test/Unit/Services/Job/DataRetrievalServiceTest.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * Apache License, Version 2.0
- * Copyright 2019-2020 NVIDIA Corporation
+ * Copyright 2019-2021 NVIDIA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -207,7 +207,7 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
                     throw new OperationCanceledException("canceled");
                 });
 
-            _jobStore.Setup(p => p.Add(It.IsAny<Job>(), It.IsAny<string>(), It.IsAny<IList<InstanceStorageInfo>>()));
+            _jobStore.Setup(p => p.Add(It.IsAny<InferenceJob>()));
             _storageInfoProvider.Setup(p => p.HasSpaceAvailableToRetrieve).Returns(true);
             _storageInfoProvider.Setup(p => p.AvailableFreeSpace).Returns(100);
             _cleanupQueue.Setup(p => p.QueueInstance(It.IsAny<string>()));
@@ -230,7 +230,7 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
             _logger.VerifyLoggingMessageBeginsWith($"Restored previously retrieved instance", LogLevel.Debug, Times.Exactly(3));
             _logger.VerifyLoggingMessageBeginsWith($"Restored previously retrieved instance", LogLevel.Debug, Times.Exactly(3));
             _logger.VerifyLoggingMessageBeginsWith($"Unable to restore previously retrieved instance from", LogLevel.Warning, Times.Once());
-            _jobStore.Verify(p => p.Add(It.IsAny<Job>(), It.IsAny<string>(), It.IsAny<IList<InstanceStorageInfo>>()), Times.Once());
+            _jobStore.Verify(p => p.Add(It.IsAny<InferenceJob>()), Times.Once());
             _storageInfoProvider.Verify(p => p.HasSpaceAvailableToRetrieve, Times.AtLeastOnce());
             _storageInfoProvider.Verify(p => p.AvailableFreeSpace, Times.Never());
             _cleanupQueue.Verify(p => p.QueueInstance(It.IsAny<string>()), Times.Exactly(3));
@@ -331,7 +331,7 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
                     throw new OperationCanceledException("canceled");
                 });
 
-            _jobStore.Setup(p => p.Add(It.IsAny<Job>(), It.IsAny<string>(), It.IsAny<IList<InstanceStorageInfo>>()));
+            _jobStore.Setup(p => p.Add(It.IsAny<InferenceJob>()));
 
             _handlerMock = new Mock<HttpMessageHandler>();
             _handlerMock
@@ -373,7 +373,7 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
                 req.RequestUri.ToString().StartsWith($"{url}studies/")),
                ItExpr.IsAny<CancellationToken>());
 
-            _jobStore.Verify(p => p.Add(It.IsAny<Job>(), It.IsAny<string>(), It.IsAny<IList<InstanceStorageInfo>>()), Times.Once());
+            _jobStore.Verify(p => p.Add(It.IsAny<InferenceJob>()), Times.Once());
 
             _dicomToolkit.Verify(p => p.Save(It.IsAny<DicomFile>(), It.IsAny<string>()), Times.Exactly(4));
             _storageInfoProvider.Verify(p => p.HasSpaceAvailableToRetrieve, Times.AtLeastOnce());
@@ -437,7 +437,7 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
                     throw new OperationCanceledException("canceled");
                 });
 
-            _jobStore.Setup(p => p.Add(It.IsAny<Job>(), It.IsAny<string>(), It.IsAny<IList<InstanceStorageInfo>>()));
+            _jobStore.Setup(p => p.Add(It.IsAny<InferenceJob>()));
 
             var studyInstanceUids = new List<string>()
             {
@@ -502,7 +502,7 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
                     req.RequestUri.ToString().StartsWith($"{url}studies/{studyInstanceUid}")),
                    ItExpr.IsAny<CancellationToken>());
             }
-            _jobStore.Verify(p => p.Add(It.IsAny<Job>(), It.IsAny<string>(), It.IsAny<IList<InstanceStorageInfo>>()), Times.Once());
+            _jobStore.Verify(p => p.Add(It.IsAny<InferenceJob>()), Times.Once());
 
             _dicomToolkit.Verify(p => p.Save(It.IsAny<DicomFile>(), It.IsAny<string>()), Times.Exactly(studyInstanceUids.Count));
             _storageInfoProvider.Verify(p => p.HasSpaceAvailableToRetrieve, Times.AtLeastOnce());
@@ -566,7 +566,7 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
                     throw new OperationCanceledException("canceled");
                 });
 
-            _jobStore.Setup(p => p.Add(It.IsAny<Job>(), It.IsAny<string>(), It.IsAny<IList<InstanceStorageInfo>>()));
+            _jobStore.Setup(p => p.Add(It.IsAny<InferenceJob>()));
 
             var studyInstanceUids = new List<string>()
             {
@@ -631,7 +631,7 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
                     req.RequestUri.ToString().StartsWith($"{url}studies/{studyInstanceUid}")),
                    ItExpr.IsAny<CancellationToken>());
             }
-            _jobStore.Verify(p => p.Add(It.IsAny<Job>(), It.IsAny<string>(), It.IsAny<IList<InstanceStorageInfo>>()), Times.Once());
+            _jobStore.Verify(p => p.Add(It.IsAny<InferenceJob>()), Times.Once());
 
             _dicomToolkit.Verify(p => p.Save(It.IsAny<DicomFile>(), It.IsAny<string>()), Times.Exactly(studyInstanceUids.Count));
             _storageInfoProvider.Verify(p => p.HasSpaceAvailableToRetrieve, Times.AtLeastOnce());

--- a/test/dicom-test-pipeline/dicom-test.yaml
+++ b/test/dicom-test-pipeline/dicom-test.yaml
@@ -34,8 +34,8 @@ operators:
   container:
       image: nvcr.io/nvidia/clara/register-results
       tag: 0.7.2-2010.1
-      # command: ["python", "register.py", "--agent", "ClaraSCU", "--data", "[\"MYPACS\"]"]
-      command: ["python", "register.py", "--agent", "DICOMweb"]
+      command: ["python", "register.py", "--agent", "ClaraSCU", "--data", "[\"MYPACS\"]"]
+      # command: ["python", "register.py", "--agent", "DICOMweb"]
   input:
   - from: dicom-test
     name: dcmout


### PR DESCRIPTION
## Description
Allow user to configure a maximum number of retries and seconds to wait before attempting a retry when connecting to Clara Platform APIs.

### Background
In the case where Clara Platform runs out of storage space, the `Jobs.Create` API throws an exception.  With this change, the user may adjust the delay based on the time required for a pipeline to execute and the value configured for the Clara Platform's payload cleanup.

### Target
v0.9

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] All tests passed locally by running `./src/run-tests-in-docker.sh`.
- [x] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [x] User guide updated.
- [ ] NGC publishing metadata updated.
- [ ] I have updated the changelog
