### PR TITLE
Make gRPC and http clients  singleton

### DIFF
--- a/src/Server/Program.cs
+++ b/src/Server/Program.cs
@@ -42,7 +42,8 @@ namespace Nvidia.Clara.DicomAdapter
 {
     public class Program
     {
-        private const int HTTPCLIENT_TIMEOUT_MINUTES = 60;
+        private const int DICOMWEB_TIMEOUT_MINUTES = 60;
+        private const int HTTP_TIMEOUT_MINUTES = 5;
         private static readonly string ApplicationEntryDirectory = AppDomain.CurrentDomain.BaseDirectory;
 
         private static void Main(string[] args)
@@ -137,9 +138,9 @@ namespace Nvidia.Clara.DicomAdapter
                     services.AddTransient<IFileSystem, FileSystem>();
                     services.AddTransient<IJobMetadataBuilderFactory, JobMetadataBuilderFactory>();
 
-                    services.AddTransient<IJobs, ClaraJobsApi>();
-                    services.AddTransient<IPayloads, ClaraPayloadsApi>();
-                    services.AddTransient<IResultsService, ResultsApi>();
+                    services.AddSingleton<IJobs, ClaraJobsApi>();
+                    services.AddSingleton<IPayloads, ClaraPayloadsApi>();
+                    services.AddSingleton<IResultsService, ResultsApi>();
 
                     services.AddTransient<IInferenceRequestRepository, InferenceRequestRepository>();
                     services.AddTransient<IJobRepository, ClaraJobRepository>();
@@ -158,8 +159,12 @@ namespace Nvidia.Clara.DicomAdapter
                     services.AddSingleton<IClaraAeChangedNotificationService, ClaraAeChangedNotificationService>();
 
                     services
-                        .AddHttpClient("dicomweb", configure => configure.Timeout = TimeSpan.FromMinutes(HTTPCLIENT_TIMEOUT_MINUTES))
-                        .SetHandlerLifetime(TimeSpan.FromMinutes(HTTPCLIENT_TIMEOUT_MINUTES));
+                        .AddHttpClient("dicomweb", configure => configure.Timeout = TimeSpan.FromMinutes(DICOMWEB_TIMEOUT_MINUTES))
+                        .SetHandlerLifetime(TimeSpan.FromMinutes(DICOMWEB_TIMEOUT_MINUTES));
+                        
+                    services
+                        .AddHttpClient("results", configure => configure.Timeout = TimeSpan.FromMinutes(HTTP_TIMEOUT_MINUTES))
+                        .SetHandlerLifetime(TimeSpan.FromMinutes(HTTP_TIMEOUT_MINUTES));
 
                     services.AddHostedService<SpaceReclaimerService>(p => p.GetService<SpaceReclaimerService>());
                     services.AddHostedService<JobSubmissionService>(p => p.GetService<JobSubmissionService>());

--- a/src/Server/Repositories/InferenceRequestRepository.cs
+++ b/src/Server/Repositories/InferenceRequestRepository.cs
@@ -68,6 +68,7 @@ namespace Nvidia.Clara.DicomAdapter.Server.Repositories
                 {
                     await _inferenceRequestRepository.AddAsync(inferenceRequest);
                     await _inferenceRequestRepository.SaveChangesAsync();
+                    _inferenceRequestRepository.Detach(inferenceRequest);
                     _logger.Log(LogLevel.Debug, $"Inference request saved.");
                 })
                 .ConfigureAwait(false);

--- a/src/Server/Repositories/ResultsApi.cs
+++ b/src/Server/Repositories/ResultsApi.cs
@@ -49,7 +49,7 @@ namespace Nvidia.Clara.DicomAdapter.Server.Repositories
 
         public async Task<IList<TaskResponse>> GetPendingJobs(string agent, CancellationToken cancellationToken, int count = 10)
         {
-            using var httpClient = _httpClientFactory.CreateClient("results");
+            var httpClient = _httpClientFactory.CreateClient("results");
             httpClient.BaseAddress = new Uri(_configuration.Value.Services.ResultsServiceEndpoint);
 
             var retryPolicy = Policy<List<TaskResponse>>
@@ -76,7 +76,7 @@ namespace Nvidia.Clara.DicomAdapter.Server.Repositories
 
         public async Task<bool> ReportFailure(Guid taskId, bool retryLater, CancellationToken cancellationToken)
         {
-            using var httpClient = _httpClientFactory.CreateClient("results");
+            var httpClient = _httpClientFactory.CreateClient("results");
             httpClient.BaseAddress = new Uri(_configuration.Value.Services.ResultsServiceEndpoint);
             
             var retryPolicy = Policy<bool>
@@ -103,7 +103,7 @@ namespace Nvidia.Clara.DicomAdapter.Server.Repositories
 
         public async Task<bool> ReportSuccess(Guid taskId, CancellationToken cancellationToken)
         {
-            using var httpClient = _httpClientFactory.CreateClient("results");
+            var httpClient = _httpClientFactory.CreateClient("results");
             httpClient.BaseAddress = new Uri(_configuration.Value.Services.ResultsServiceEndpoint);
             
             var retryPolicy = Policy<bool>

--- a/src/Server/Services/Jobs/DataRetrievalService.cs
+++ b/src/Server/Services/Jobs/DataRetrievalService.cs
@@ -198,9 +198,11 @@ namespace Nvidia.Clara.DicomAdapter.Server.Services.Jobs
                 {
                     JobId = inferenceRequest.JobId,
                     PayloadId = inferenceRequest.PayloadId,
+                    PipelineId = inferenceRequest.Algorithm.PipelineId,
                     JobName = inferenceRequest.JobName,
                     Instances = instances.ToList(),
-                    State = InferenceJobState.Created
+                    State = InferenceJobState.Created,
+                    Source = inferenceRequest.TransactionId
                 }, false);
         }
 

--- a/src/Server/Test/Integration/DicomAdapterFixture.cs
+++ b/src/Server/Test/Integration/DicomAdapterFixture.cs
@@ -236,9 +236,9 @@ namespace Nvidia.Clara.DicomAdapter.Test.Integration
                      services.AddTransient<IFileSystem, FileSystem>();
                      services.AddTransient<IJobMetadataBuilderFactory, JobMetadataBuilderFactory>();
 
-                     services.AddTransient<IJobs>(p => Jobs.Object);
-                     services.AddTransient<IPayloads>(p => Payloads.Object);
-                     services.AddTransient<IResultsService>(p => ResultsService.Object);
+                     services.AddSingleton<IJobs>(p => Jobs.Object);
+                     services.AddSingleton<IPayloads>(p => Payloads.Object);
+                     services.AddSingleton<IResultsService>(p => ResultsService.Object);
 
                      services.AddTransient<IJobRepository, ClaraJobRepository>();
                      services.AddTransient<IInferenceRequestRepository, InferenceRequestRepository>();

--- a/src/Server/Test/Unit/Processors/AeTitleJobProcessorTest.cs
+++ b/src/Server/Test/Unit/Processors/AeTitleJobProcessorTest.cs
@@ -193,7 +193,7 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
             var processor = new AeTitleJobProcessor(_configuration, _notificationService, _loggerFactory.Object, _jobStore.Object, _cleanupQueue.Object, _dicomToolkit.Object, _cancellationTokenSource.Token);
 
             _notificationService.NewInstanceStored(_instances.First());
-            Assert.True(countDownEvent.Wait(7000));
+            Assert.True(countDownEvent.Wait(10000));
 
             _jobStore.Verify(p => p.Add(It.IsAny<InferenceJob>(), false), Times.Exactly(3));
             _logger.VerifyLogging($"Failed to submit job, will retry later: PatientId={_instances.First().PatientId}, Study={_instances.First().StudyInstanceUid}", LogLevel.Information, Times.AtLeast(1));

--- a/src/Server/Test/Unit/Repositories/ResultsApiTest.cs
+++ b/src/Server/Test/Unit/Repositories/ResultsApiTest.cs
@@ -35,6 +35,13 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
 {
     public class ResultsApiTest
     {
+        private Mock<IHttpClientFactory> _httpClientFactory;
+
+        public ResultsApiTest()
+        {
+            _httpClientFactory = new Mock<IHttpClientFactory>();
+        }
+
         [RetryFact(DisplayName = "GetPendingJobs shall return null on API call failures")]
         public async Task GetPendingJobs_ShallReturnNullOnCallFailures()
         {
@@ -62,7 +69,8 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
             {
                 BaseAddress = new Uri("http://test.com/"),
             };
-            var subjectUnderTest = new ResultsApi(config, httpClient, mockLogger.Object);
+            _httpClientFactory.Setup(p => p.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var subjectUnderTest = new ResultsApi(config, _httpClientFactory.Object, mockLogger.Object);
 
             // ACT
             var result = await subjectUnderTest.GetPendingJobs(config.Value.Dicom.Scu.AeTitle, CancellationToken.None, 10);
@@ -114,7 +122,8 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
                 BaseAddress = new Uri("http://test.com/"),
             };
 
-            var subjectUnderTest = new ResultsApi(config, httpClient, mockLogger.Object);
+            _httpClientFactory.Setup(p => p.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var subjectUnderTest = new ResultsApi(config, _httpClientFactory.Object, mockLogger.Object);
 
             // ACT
             var result = await subjectUnderTest.GetPendingJobs(config.Value.Dicom.Scu.AeTitle, CancellationToken.None, 10);
@@ -162,7 +171,8 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
             {
                 BaseAddress = new Uri("http://test.com/"),
             };
-            var subjectUnderTest = new ResultsApi(config, httpClient, mockLogger.Object);
+            _httpClientFactory.Setup(p => p.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var subjectUnderTest = new ResultsApi(config, _httpClientFactory.Object, mockLogger.Object);
             var taskId = Guid.NewGuid();
 
             // ACT
@@ -217,7 +227,8 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
                 BaseAddress = new Uri("http://test.com/"),
             };
 
-            var subjectUnderTest = new ResultsApi(config, httpClient, mockLogger.Object);
+            _httpClientFactory.Setup(p => p.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var subjectUnderTest = new ResultsApi(config, _httpClientFactory.Object, mockLogger.Object);
             var taskId = Guid.NewGuid();
 
             // ACT
@@ -266,7 +277,8 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
             {
                 BaseAddress = new Uri("http://test.com/"),
             };
-            var subjectUnderTest = new ResultsApi(config, httpClient, mockLogger.Object);
+            _httpClientFactory.Setup(p => p.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var subjectUnderTest = new ResultsApi(config, _httpClientFactory.Object, mockLogger.Object);
             var taskId = Guid.NewGuid();
 
             // ACT
@@ -318,7 +330,8 @@ namespace Nvidia.Clara.DicomAdapter.Test.Unit
                 BaseAddress = new Uri("http://test.com/"),
             };
 
-            var subjectUnderTest = new ResultsApi(config, httpClient, mockLogger.Object);
+            _httpClientFactory.Setup(p => p.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            var subjectUnderTest = new ResultsApi(config, _httpClientFactory.Object, mockLogger.Object);
             var taskId = Guid.NewGuid();
 
             // ACT


### PR DESCRIPTION
### Description
Optimize memory usage by switching gRPC & HTTP API clients to a singleton.  
Update Results Service API to use HttpClientFactory.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] All tests passed locally by running `./src/run-tests-in-docker.sh`.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [ ] NGC publishing metadata updated.
- [ ] I have updated the changelog
