### PR TITLE
Update NGC metadata & default watermark 

### DIFF
--- a/docs/setup/schema.md
+++ b/docs/setup/schema.md
@@ -75,7 +75,7 @@ database:
     },
     "storage" : {
       "temporary" : "/payloads", // storage path used for storing received instances before uploading to Clara Platform.
-      "watermarkPercent": 85, // storage space usage watermark to stop storing, exporting and retrieving of DICOM instances.
+      "watermarkPercent": 75, // storage space usage watermark to stop storing, exporting and retrieving of DICOM instances.
       "reserveSpaceGB": 5 // minimal storage space required to store, export and retrieve DICOM instances.
     }
   },

--- a/docs/setup/setup.md
+++ b/docs/setup/setup.md
@@ -66,7 +66,7 @@ The default settings enable DICOM *C-STORE SCP* and *C-STORE-SCU* and set listen
     },
     "storage" : {
       "temporary" : "/payloads",
-      "watermarkPercent": 85,
+      "watermarkPercent": 75,
       "reserveSpaceGB": 5
     }
   },

--- a/helm-chart/dicom-adapter/files/appsettings.json
+++ b/helm-chart/dicom-adapter/files/appsettings.json
@@ -17,7 +17,7 @@
     },
     "storage" : {
       "temporary" : "/payloads",
-      "watermarkPercent": 85,
+      "watermarkPercent": 75,
       "reserveSpaceGB": 5
     },
     "services": {

--- a/helm-chart/ngc/overview.md
+++ b/helm-chart/ngc/overview.md
@@ -1,7 +1,7 @@
 # Clara DICOM Adapter Helm Chart
 
 This asset requires the Clara Deploy SDK. Follow the instructions on the
-[Clara Bootstrap]($NGC_HOST/model-scripts/$NGC_ORG:$NGC_TEAM:clara_bootstrap) page
+[Clara Ansible]($NGC_HOST/model-scripts/$NGC_ORG:$NGC_TEAM:clara_ansible) page
 to install the Clara Deploy SDK.
 
 ## Install via Clara CLI

--- a/src/Configuration/StorageConfiguration.cs
+++ b/src/Configuration/StorageConfiguration.cs
@@ -37,14 +37,14 @@ namespace Nvidia.Clara.DicomAdapter.Configuration
         public string Temporary { get; set; } = "./payloads";
 
         /// <summary>
-        /// Gets or sets the watermark for disk usage with default value of 85%,
+        /// Gets or sets the watermark for disk usage with default value of 75%,
         /// meaning that DICOM Adapter will stop accepting (C-STORE-RQ) assocations,
         /// stop exporting and stop retreiving data via DICOMweb when used disk space
         /// is above the watermark.
         /// </summary>
         /// <value></value>
         [JsonProperty(PropertyName = "watermarkPercent")]
-        public uint Watermark { get; set; } = 85;
+        public uint Watermark { get; set; } = 75;
 
         /// <summary>
         /// Gets or sets the reserved disk space for DICOM Adapter with default value of 5GB.


### PR DESCRIPTION
Fixes #85  .

### Description
* Update NGC metadata to reference Ansible instead of Bootstrap.
* Set storage->watermarkPercent to 75% as k8s begins to react to storage depletion around 80%.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] All tests passed locally by running `./src/run-tests-in-docker.sh`.
- [ ] [Documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/documentation-comments) included/updated.
- [ ] User guide updated.
- [x] NGC publishing metadata updated.
- [ ] I have updated the changelog
